### PR TITLE
Fix repository url

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2019 Yuki Yamazaki
+Copyright (c) 2019-2020 Yuki Yamazaki
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ digraph "G" {
 
 Graphviz-dot Test and Integration
 
-- [jest-graphviz](https://github.com/kamiazya/jest-graphviz)
+- [@ts-graphviz/react](https://github.com/ts-graphviz/react)
+  - Graphviz-dot Renderer for React.
+- [jest-graphviz](https://github.com/ts-graphviz/jest-graphviz)
   - Jest matchers that supports graphviz integration.
 - [setup-graphviz](https://github.com/kamiazya/setup-graphviz)
   - GitHub Action to set up Graphviz cross-platform(Linux, macOS, Windows).
@@ -138,4 +140,4 @@ For more info on how to contribute to ts-graphviz, see the [docs](./CONTRIBUTING
 
 ## License
 
-This software is released under the MIT License, see LICENSE.
+This software is released under the MIT License, see [LICENSE](./LICENSE).

--- a/package.json
+++ b/package.json
@@ -3,17 +3,17 @@
   "version": "0.10.0",
   "author": "kamiazya <yuki@kamiazya.tech>",
   "description": "Graphviz library for TypeScript.",
-  "homepage": "https://kamiazya.github.io/ts-graphviz/",
+  "homepage": "https://ts-graphviz.github.io/ts-graphviz/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/kamiazya/ts-graphviz.git"
+    "url": "https://github.com/ts-graphviz/ts-graphviz.git"
   },
   "keywords": [
     "graphviz",
     "dot"
   ],
   "bugs": {
-    "url": "https://github.com/kamiazya/ts-graphviz/issues"
+    "url": "https://github.com/ts-graphviz/ts-graphviz/issues"
   },
   "funding": {
     "type": "github",


### PR DESCRIPTION
<!-- Thank you for your contribution to ts-graphviz! Please replace {Please write here} with your description -->

### What was a problem

The repository path is incorrect due to the effect of migrating the repository to the ts-graphviz organization.

### How this PR fixes the problem

Corrected to the correct path.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)
