### PR TITLE
Add ForwardRefNode object

### DIFF
--- a/src/__test__/__snapshots__/usecase.spec.ts.snap
+++ b/src/__test__/__snapshots__/usecase.spec.ts.snap
@@ -13,7 +13,6 @@ digraph "G" {
       color = "violet",
     ];
     "Acc";
-    "E";
     "Aaa":"a" -> "Abb" -> "Acc" -> "E" [
       color = "red",
     ];

--- a/src/model/Context.ts
+++ b/src/model/Context.ts
@@ -1,7 +1,8 @@
 import { Compass, EdgeTargetLike, ICluster, IContext, IEdgeTarget, RootClusterType } from '../types';
+import { concatWordsWithColon } from '../utils/dot-rendering';
 import { Attributes } from './Attributes';
 import { Edge } from './Edge';
-import { isEdgeTarget, isEdgeTargetLike, Node } from './Node';
+import { ForwardRefNode, isEdgeTarget, isEdgeTargetLike, Node } from './Node';
 import { RootCluster } from './RootCluster';
 import { Subgraph } from './Subgraph';
 
@@ -67,10 +68,16 @@ export class Context implements IContext {
       return node;
     }
     const [id, port, compass] = node.split(':');
-    const n = cluster.node(id);
-    if (port && (compass === undefined || Compass.is(compass))) {
-      return n.port({ port, compass });
+    const n = cluster.getNode(id);
+    if (n !== undefined) {
+      if (port && (compass === undefined || Compass.is(compass))) {
+        return n.port({ port, compass });
+      }
+      return n;
     }
-    return n;
+    if (Compass.is(compass)) {
+      return new ForwardRefNode(id, { port, compass });
+    }
+    return new ForwardRefNode(id, { port });
   }
 }

--- a/src/model/Node.ts
+++ b/src/model/Node.ts
@@ -65,10 +65,31 @@ export class NodeWithPort implements INodeWithPort {
 }
 
 /**
+ * @category Primary
+ * @hidden
+ */
+export class ForwardRefNode implements INodeWithPort {
+  public readonly id: ID;
+  public readonly port?: ID;
+  /** Specify the direction of the edge. */
+  public readonly compass?: Compass;
+  constructor(id: string, port: Partial<IPort>) {
+    this.id = new ID(id);
+    this.port = port.port ? new ID(port.port) : undefined;
+    this.compass = port.compass;
+  }
+
+  /** Converts a NodeWithPort to an EdgeTarget. */
+  public toEdgeTargetDot() {
+    return concatWordsWithColon(this.id.toDot(), this.port?.toDot(), this.compass);
+  }
+}
+
+/**
  * @hidden
  */
 export function isEdgeTarget(node: any): node is IEdgeTarget {
-  return node instanceof Node || node instanceof NodeWithPort;
+  return node instanceof Node || node instanceof NodeWithPort || node instanceof ForwardRefNode;
 }
 
 /**


### PR DESCRIPTION
<!-- Thank you for your contribution to ts-graphviz! Please replace {Please write here} with your description -->

### What was a problem

When undeclared Node was used as the target of Edge, there was a problem that Node was declared in the cluster.

### How this PR fixes the problem

An object for handling an undefined Node called ForwardRefNode is used internally, and it is modified so that Node is not declared in the cluster.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)
