### PR TITLE
Add grouped edge target

### DIFF
--- a/src/model/__tests__/clusters.spec.ts
+++ b/src/model/__tests__/clusters.spec.ts
@@ -69,11 +69,21 @@ describe('class Subgraph', () => {
   });
 
   test('create edge with attributes', () => {
-    const nodes = ['node1', 'node2'].map((id) => subgraph.createNode(id));
+    const nodes = Array(2)
+      .fill(true)
+      .map((_v, i) => subgraph.createNode(`node${i + 1}`));
     const edge = subgraph.createEdge(nodes, {
       [attribute.label]: 'Label',
     });
     expect(edge.attributes.size).toBe(1);
+  });
+
+  test('create edge by node group', () => {
+    const [node1, node2, node3, node4] = Array(4)
+      .fill(true)
+      .map((_v, i) => subgraph.createNode(`node${i + 1}`));
+    const edge = subgraph.createEdge([node1, [node2, node3], node4]);
+    expect(edge.targets.length).toBe(3);
   });
 
   test('create subgraph with attributes', () => {
@@ -115,7 +125,9 @@ describe('class Subgraph', () => {
     });
 
     it('Edge operation methods works', () => {
-      const nodes = ['node1', 'node2'].map((id) => subgraph.createNode(id));
+      const nodes = Array(2)
+        .fill(true)
+        .map((_v, i) => subgraph.createNode(`node${i + 1}`));
       const edge = subgraph.createEdge(nodes);
       expect(subgraph.existEdge(edge)).toBe(true);
       subgraph.removeEdge(edge);

--- a/src/model/clusters.ts
+++ b/src/model/clusters.ts
@@ -12,9 +12,11 @@ import {
   INode,
   ISubgraph,
   NodeAttributes,
+  EdgeTargetsLike,
+  EdgeTargets,
 } from '../types';
 import { Attributes, AttributesBase } from './attributes-base';
-import { isEdgeTarget, isEdgeTargetLike, Node, ForwardRefNode } from './nodes';
+import { isEdgeTarget, isEdgeTargetLike, Node, ForwardRefNode, isEdgeTargetsLike } from './nodes';
 import { Edge } from './edges';
 
 /**
@@ -170,12 +172,12 @@ export abstract class Cluster<T extends string> extends AttributesBase<T> implem
   }
 
   /** Create Edge and add it to the cluster. */
-  public createEdge(targets: EdgeTargetLike[], attributes?: EdgeAttributes): IEdge {
+  public createEdge(targets: (EdgeTargetLike | EdgeTargetsLike)[], attributes?: EdgeAttributes): IEdge {
     if (targets.length < 2 && (isEdgeTargetLike(targets[0]) && isEdgeTargetLike(targets[1])) === false) {
       throw Error('The element of Edge target is missing or not satisfied as Edge target.');
     }
     const edge = new Edge(
-      targets.map((t) => this.toEdgeTarget(t)),
+      targets.map((t) => (isEdgeTargetsLike(t) ? this.toEdgeTargets(t) : this.toEdgeTarget(t))),
       attributes,
     );
     this.objects.edges.add(edge);
@@ -199,6 +201,14 @@ export abstract class Cluster<T extends string> extends AttributesBase<T> implem
       return new ForwardRefNode(id, { port, compass });
     }
     return new ForwardRefNode(id, { port });
+  }
+
+  /** @hidden */
+  private toEdgeTargets(targets: EdgeTargetsLike): EdgeTargets {
+    if (targets.length < 2 && (isEdgeTargetLike(targets[0]) && isEdgeTargetLike(targets[1])) === false) {
+      throw Error('EdgeTargets must have at least 2 elements.');
+    }
+    return targets.map((t) => this.toEdgeTarget(t));
   }
 
   /**

--- a/src/model/edges.ts
+++ b/src/model/edges.ts
@@ -1,4 +1,4 @@
-import { EdgeTarget, EdgeAttributes, IAttributes } from '../types';
+import { EdgeTarget, EdgeAttributes, IAttributes, EdgeTargets } from '../types';
 import { DotObject } from './abstract';
 import { attribute } from '../attribute';
 import { Attributes } from './attributes-base';
@@ -11,7 +11,7 @@ export class Edge extends DotObject {
   public comment?: string;
   public readonly attributes: IAttributes<attribute.Edge>;
 
-  constructor(public readonly targets: ReadonlyArray<EdgeTarget>, attributes?: EdgeAttributes) {
+  constructor(public readonly targets: ReadonlyArray<EdgeTarget | EdgeTargets>, attributes?: EdgeAttributes) {
     super();
     this.attributes = new Attributes<attribute.Edge>(attributes);
   }

--- a/src/model/nodes.ts
+++ b/src/model/nodes.ts
@@ -11,6 +11,7 @@ import {
 import { DotObject } from './abstract';
 import { attribute } from '../attribute';
 import { Attributes } from './attributes-base';
+import { EdgeTargetsLike } from '../types';
 
 /**
  * @category Primary
@@ -62,4 +63,10 @@ export function isEdgeTarget(node: unknown): node is EdgeTarget {
  */
 export function isEdgeTargetLike(node: unknown): node is EdgeTargetLike {
   return typeof node === 'string' || isEdgeTarget(node);
+}
+/**
+ * @hidden
+ */
+export function isEdgeTargetsLike(target: EdgeTargetLike | EdgeTargetsLike): target is EdgeTargetsLike {
+  return Array.isArray(target) && target.every(isEdgeTargetLike);
 }

--- a/src/render/__tests__/__snapshots__/edges.spec.ts.snap
+++ b/src/render/__tests__/__snapshots__/edges.spec.ts.snap
@@ -1,14 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Edge rendering Digraph context 3 nodes 1`] = `
+exports[`Edge rendering Digraph context custom edge 3 nodes 1`] = `
 digraph {
-  "node1" -> "node2";
+  "node1" -> "node2" -> "node3";
 }
 `;
 
-exports[`Edge rendering Digraph context 3 nodes, but many args 1`] = `
+exports[`Edge rendering Digraph context custom edge 3 nodes, but many args 1`] = `
 digraph {
-  "node1" -> "node2";
+  "node1" -> "node2" -> "node3" -> "node1" -> "node2" -> "node3" -> "node1" -> "node2" -> "node3";
+}
+`;
+
+exports[`Edge rendering Digraph context custom edge node group 1`] = `
+digraph {
+  "node1" -> {"node2" "node3"} -> "node4";
 }
 `;
 
@@ -42,15 +48,21 @@ digraph {
 }
 `;
 
-exports[`Edge rendering Graph context 3 nodes 1`] = `
+exports[`Edge rendering Graph context custom edge 3 nodes 1`] = `
 graph {
-  "node1" -- "node2";
+  "node1" -- "node2" -- "node3";
 }
 `;
 
-exports[`Edge rendering Graph context 3 nodes, but many args 1`] = `
+exports[`Edge rendering Graph context custom edge 3 nodes, but many args 1`] = `
 graph {
-  "node1" -- "node2";
+  "node1" -- "node2" -- "node3" -- "node1" -- "node2" -- "node3" -- "node1" -- "node2" -- "node3";
+}
+`;
+
+exports[`Edge rendering Graph context custom edge node group 1`] = `
+graph {
+  "node1" -- {"node2" "node3"} -- "node4";
 }
 `;
 

--- a/src/render/__tests__/edges.spec.ts
+++ b/src/render/__tests__/edges.spec.ts
@@ -8,7 +8,7 @@ import { IRootCluster } from '../../types';
 describe('Edge rendering', () => {
   let edge: Edge;
 
-  const [node1, node2, node3] = Array(3)
+  const [node1, node2, node3, node4] = Array(4)
     .fill(true)
     .map((_, i) => new Node(`node${i + 1}`));
 
@@ -47,14 +47,28 @@ describe('Edge rendering', () => {
       expect(toDot(root)).toBeValidDotAndMatchSnapshot();
     });
 
-    it('3 nodes', () => {
-      edge = new Edge([node1, node2, node3]);
-      expect(toDot(root)).toBeValidDotAndMatchSnapshot();
-    });
+    describe('custom edge', () => {
+      beforeEach(() => {
+        root = create();
+      });
 
-    it('3 nodes, but many args', () => {
-      edge = new Edge([node1, node2, node3, node1, node2, node3, node1, node2, node3]);
-      expect(toDot(root)).toBeValidDotAndMatchSnapshot();
+      it('node group', () => {
+        edge = new Edge([node1, [node2, node3], node4]);
+        root.addEdge(edge);
+        expect(toDot(root)).toBeValidDotAndMatchSnapshot();
+      });
+
+      it('3 nodes', () => {
+        edge = new Edge([node1, node2, node3]);
+        root.addEdge(edge);
+        expect(toDot(root)).toBeValidDotAndMatchSnapshot();
+      });
+
+      it('3 nodes, but many args', () => {
+        edge = new Edge([node1, node2, node3, node1, node2, node3, node1, node2, node3]);
+        root.addEdge(edge);
+        expect(toDot(root)).toBeValidDotAndMatchSnapshot();
+      });
     });
   });
 });

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -1,4 +1,6 @@
 import { Dot, INode, ISubgraph, ICluster, IEdge, IRootCluster } from '../types';
+import { isEdgeTargetLike } from '../model/nodes';
+import { renderEdgeTargets } from './utils';
 import {
   commentOutIfExist,
   concatWordsWithSpace,
@@ -32,7 +34,10 @@ export class Renderer {
 
   protected renderEdge(edge: IEdge): string {
     const comment = commentOutIfExist(edge.comment);
-    const targets = joinWith(isGraph(this.root) ? ' -- ' : ' -> ', edge.targets.map(renderEdgeTarget));
+    const targets = joinWith(
+      isGraph(this.root) ? ' -- ' : ' -> ',
+      edge.targets.map((t) => (isEdgeTargetLike(t) ? renderEdgeTarget(t) : renderEdgeTargets(t))),
+    );
     const attrs = edge.attributes.size > 0 ? spaceLeftPad(renderAttributes(edge.attributes)) : undefined;
     const dot = join(targets, attrs, ';');
     return joinLines(comment, dot);

--- a/src/render/utils.ts
+++ b/src/render/utils.ts
@@ -1,4 +1,14 @@
-import { ICluster, ISubgraph, IEdge, INode, IRootCluster, IAttributes, AttributesValue, EdgeTarget } from '../types';
+import {
+  ICluster,
+  ISubgraph,
+  IEdge,
+  INode,
+  IRootCluster,
+  IAttributes,
+  AttributesValue,
+  EdgeTarget,
+  EdgeTargets,
+} from '../types';
 import { Subgraph } from '../model/clusters';
 import { Edge } from '../model/edges';
 import { Node, NodeWithPort, ForwardRefNode } from '../model/nodes';
@@ -179,4 +189,8 @@ export function renderEdgeTarget(edgeTarget: EdgeTarget): string | undefined {
       compass !== undefined ? renderAttributeValue(compass) : undefined,
     );
   }
+}
+
+export function renderEdgeTargets(edgeTargets: EdgeTargets): string | undefined {
+  return '{' + concatWordsWithSpace(...edgeTargets.map(renderEdgeTarget)) + '}';
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,11 +37,14 @@ export namespace Compass {
  * Objects that can be Edge destinations satisfy this interface.
  */
 export type EdgeTarget = INode | INodeWithPort | IForwardRefNode;
+export type EdgeTargets = ReadonlyArray<EdgeTarget>;
 
 /**
  * string or an object implementing IEdgeTarget.
  */
 export type EdgeTargetLike = EdgeTarget | string;
+
+export type EdgeTargetsLike = ReadonlyArray<EdgeTargetLike>;
 
 export interface IHasComment {
   /** Comments to include when outputting with toDot. */
@@ -105,7 +108,7 @@ export interface INode extends IHasComment, IHasAttributes<attribute.Node> {
 }
 
 export interface IEdge extends IHasComment, IHasAttributes<attribute.Edge> {
-  readonly targets: ReadonlyArray<EdgeTarget>;
+  readonly targets: ReadonlyArray<EdgeTarget | EdgeTargets>;
 }
 
 /**
@@ -188,7 +191,7 @@ export interface ICluster<T extends string = string> extends IHasComment, IAttri
    */
   getNode(id: string): INode | undefined;
   /** Create Edge and add it to the cluster. */
-  createEdge(targets: EdgeTargetLike[], attributes?: EdgeAttributes): IEdge;
+  createEdge(targets: (EdgeTargetLike | EdgeTargetsLike)[], attributes?: EdgeAttributes): IEdge;
   /**
    * Declarative API for Subgraph.
    *
@@ -225,8 +228,12 @@ export interface ICluster<T extends string = string> extends IHasComment, IAttri
    * @param attributes Edge attributes.
    * @param callback Callback to operate Edge.
    */
-  edge(targets: EdgeTargetLike[], callback?: (edge: IEdge) => void): IEdge;
-  edge(targets: EdgeTargetLike[], attributes?: EdgeAttributes, callback?: (edge: IEdge) => void): IEdge;
+  edge(targets: (EdgeTargetLike | EdgeTargetsLike)[], callback?: (edge: IEdge) => void): IEdge;
+  edge(
+    targets: (EdgeTargetLike | EdgeTargetsLike)[],
+    attributes?: EdgeAttributes,
+    callback?: (edge: IEdge) => void,
+  ): IEdge;
 }
 
 export interface ISubgraph extends ICluster<attribute.Subgraph | attribute.ClusterSubgraph> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     "src/**/*.ts"
   ],
   "exclude": [
-    "src/**/*.spec.ts"
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
   ]
 }


### PR DESCRIPTION
### What was a problem

Could not group Edge targets.

### How this PR fixes the problem

When creating Edges, specify the Nodes as an array so that they can be grouped.

```ts
const root = new Digraph();
const [node1, node2, node3, node4] = Array(4)
    .fill(true)
    .map((_, i) => root.createNode(`node${i + 1}`));
const edge = new Edge([node1, [node2, node3], node4]);
root.addEdge(edge);
console.log(toDot(root));
```

to be

```dot
digraph {
  "node1" -> {"node2" "node3"} -> "node4";
}
```

![result](https://user-images.githubusercontent.com/35218186/82566400-d3eb7c80-9bb6-11ea-819e-65798f9fd769.png)

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)
