### PR TITLE
add attribute undefined value validation

### DIFF
--- a/src/model/attributes-base.ts
+++ b/src/model/attributes-base.ts
@@ -29,7 +29,9 @@ export abstract class AttributesBase<T extends string> extends DotObject impleme
   }
   /** Set a value to the attribute. */
   public set(key: T, value: AttributesValue): void {
-    this.attrs.set(key, value);
+    if (value !== null && value !== undefined) {
+      this.attrs.set(key, value);
+    }
   }
 
   public delete(key: T): void {

--- a/src/render/__tests__/__snapshots__/attributes.test.ts.snap
+++ b/src/render/__tests__/__snapshots__/attributes.test.ts.snap
@@ -33,6 +33,8 @@ exports[`Attributes rendering renders correctly by toDot method set some attribu
 ]"
 `;
 
+exports[`Attributes rendering renders correctly by toDot method set undefined attributes by apply 1`] = `""`;
+
 exports[`Attributes rendering renders correctly by toDot method some attributes 1`] = `
 "[
   label = \\"test\\",

--- a/src/render/__tests__/attributes.test.ts
+++ b/src/render/__tests__/attributes.test.ts
@@ -1,5 +1,6 @@
 import { toDot } from '../../render/to-dot';
 import { Attributes } from '../../model/attributes-base';
+import { attribute } from '../../attribute';
 
 describe('Attributes rendering', () => {
   let attrs: Attributes;
@@ -29,6 +30,14 @@ describe('Attributes rendering', () => {
         color: 'red',
         fontsize: 16,
       });
+      expect(toDot(attrs)).toMatchSnapshot();
+    });
+
+    test('set undefined attributes by apply', () => {
+      attrs.apply({
+        label: undefined,
+      });
+      expect(attrs.size).toBe(0);
       expect(toDot(attrs)).toMatchSnapshot();
     });
 

--- a/src/render/__tests__/attributes.test.ts
+++ b/src/render/__tests__/attributes.test.ts
@@ -1,6 +1,5 @@
 import { toDot } from '../../render/to-dot';
 import { Attributes } from '../../model/attributes-base';
-import { attribute } from '../../attribute';
 
 describe('Attributes rendering', () => {
   let attrs: Attributes;


### PR DESCRIPTION
<!-- Thank you for your contribution to ts-graphviz! Please replace {Please write here} with your description -->

### What was a problem

There was a problem that rendering failed when undefined was included when the value was reflected in the attribute as an object.

```ts

const subgraph = new Subgraph();
subgraph.apply({
  color: undefined,
});
toDot(subgraph); // throw Error
```

### How this PR fixes the problem

Fixed to check whether null or undefined is included when setting the value.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)
