### PR TITLE
Fix edge targets validation

### DIFF
--- a/src/model/__tests__/clusters.spec.ts
+++ b/src/model/__tests__/clusters.spec.ts
@@ -153,12 +153,8 @@ describe('class Subgraph', () => {
 
     it('throws an error when the EdgeTarget element is missing', () => {
       const n = subgraph.node('n');
-      expect(() => {
-        subgraph.edge([]);
-      }).toThrow();
-      expect(() => {
-        subgraph.edge([n]);
-      }).toThrow();
+      expect(() => subgraph.edge([])).toThrow();
+      expect(() => subgraph.edge([n])).toThrow();
     });
   });
 });

--- a/src/model/__tests__/edges.spec.ts
+++ b/src/model/__tests__/edges.spec.ts
@@ -24,6 +24,12 @@ describe('class Edge', () => {
     });
   });
 
+  it('throws an error when the EdgeTarget element is missing', () => {
+    const n = new Node('id');
+    expect(() => new Edge([])).toThrow();
+    expect(() => new Edge([n])).toThrow();
+  });
+
   it('should be instance of Edge/DotObject/GraphvizObject', () => {
     expect(edge).toBeInstanceOf(Edge);
     expect(edge).toBeInstanceOf(DotObject);

--- a/src/model/clusters.ts
+++ b/src/model/clusters.ts
@@ -173,9 +173,6 @@ export abstract class Cluster<T extends string> extends AttributesBase<T> implem
 
   /** Create Edge and add it to the cluster. */
   public createEdge(targets: (EdgeTargetLike | EdgeTargetsLike)[], attributes?: EdgeAttributes): IEdge {
-    if (targets.length < 2 && (isEdgeTargetLike(targets[0]) && isEdgeTargetLike(targets[1])) === false) {
-      throw Error('The element of Edge target is missing or not satisfied as Edge target.');
-    }
     const edge = new Edge(
       targets.map((t) => (isEdgeTargetsLike(t) ? this.toEdgeTargets(t) : this.toEdgeTarget(t))),
       attributes,

--- a/src/model/edges.ts
+++ b/src/model/edges.ts
@@ -2,6 +2,7 @@ import { EdgeTarget, EdgeAttributes, IAttributes, EdgeTargets } from '../types';
 import { DotObject } from './abstract';
 import { attribute } from '../attribute';
 import { Attributes } from './attributes-base';
+import { isEdgeTargetLike } from './nodes';
 
 /**
  * @category Primary
@@ -13,6 +14,9 @@ export class Edge extends DotObject {
 
   constructor(public readonly targets: ReadonlyArray<EdgeTarget | EdgeTargets>, attributes?: EdgeAttributes) {
     super();
+    if (targets.length < 2 && (isEdgeTargetLike(targets[0]) && isEdgeTargetLike(targets[1])) === false) {
+      throw Error('The element of Edge target is missing or not satisfied as Edge target.');
+    }
     this.attributes = new Attributes<attribute.Edge>(attributes);
   }
 }


### PR DESCRIPTION
### What was a problem

When creating `createEdge` from Cluster, an error is output by checking the number and type of EdgeTarget, but no error is output when creating by `new Edge(...)`.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

close #151
