### PR TITLE
Added API to specify common attributes in a cluster.

### DIFF
--- a/src/model/__tests__/clusters.spec.ts
+++ b/src/model/__tests__/clusters.spec.ts
@@ -37,6 +37,29 @@ describe('class Subgraph', () => {
     });
   });
 
+  describe('Declaratively set the attributes of the objects in the cluster', () => {
+    test('node', () => {
+      subgraph.node({
+        label: 'test label',
+      });
+      expect(subgraph.attributes.node.get(attribute.label)).toBe('test label');
+    });
+
+    test('edge', () => {
+      subgraph.edge({
+        label: 'test label',
+      });
+      expect(subgraph.attributes.edge.get(attribute.label)).toBe('test label');
+    });
+
+    test('graph', () => {
+      subgraph.graph({
+        label: 'test label',
+      });
+      expect(subgraph.attributes.graph.get(attribute.label)).toBe('test label');
+    });
+  });
+
   test('set attributes', () => {
     subgraph.set(attribute.rank, 'same');
     expect(subgraph.get(attribute.rank)).toBe('same');

--- a/src/model/clusters.ts
+++ b/src/model/clusters.ts
@@ -209,22 +209,99 @@ export abstract class Cluster<T extends string> extends AttributesBase<T> implem
   }
 
   /**
-   * Declarative API for Subgraph.
+   * Create a subgraph by specifying its id (or get it if it already exists).
    *
-   * @description
-   * If there is a Subgraph with the given ID, use it.
-   * If not, create a Subgraph.
+   * By specifying a callback function, the target subgraph can be received and manipulated as an argument.
+   *
+   * ```ts
+   * const G = digraph('G', (g) => {
+   *   // Create a cluster with id as A.
+   *   g.subgraph('A', (A) => {
+   *     // Create a node with id as A1 in cluster A.
+   *     A.node('A1');
+   *   });
+   * });
+   *
+   * console.log(toDot(G));
+   * // digraph "G" {
+   * //   subgraph "A" {
+   * //     "A1";
+   * //   }
+   * // }
+   * ```
    *
    * @param id Subgraph ID.
-   * @param callback Callback to operate Subgraph.
+   * @param callback Callbacks for manipulating created or retrieved subgraph.
    */
-  public subgraph(id?: string, callback?: (subgraph: ISubgraph) => void): ISubgraph;
+  public subgraph(id: string, callback?: (subgraph: ISubgraph) => void): ISubgraph;
+  /**
+   * Create a subgraph (or get one if it already exists) and adapt the attributes.
+   *
+   * By specifying a callback function, the target subgraph can be received and manipulated as an argument.
+   *
+   * ```ts
+   * const G = digraph('G', (g) => {
+   *   // Create a cluster with id as A and specifying its attributes.
+   *   g.subgraph('A', { [attribute.color]: 'red', [attribute.label]: 'my label' }, (A) => {
+   *     // Create a node with id as A1 in cluster A.
+   *     A.node('A1');
+   *   });
+   * });
+   *
+   * console.log(toDot(G));
+   * // digraph "G" {
+   * //   subgraph "A" {
+   * //     color = "red";
+   * //     label = "my label";
+   * //     "A1";
+   * //   }
+   * // }
+   * ```
+   *
+   * @param id  Subgraph ID.
+   * @param attributes Object of attributes to be adapted to the subgraph.
+   * @param callback Callbacks for manipulating created or retrieved subgraph.
+   */
   public subgraph(
-    id?: string,
-    attributes?: ClusterSubgraphAttributes,
+    id: string,
+    attributes: ClusterSubgraphAttributes,
     callback?: (subgraph: ISubgraph) => void,
   ): ISubgraph;
-  public subgraph(attributes?: ClusterSubgraphAttributes, callback?: (subgraph: ISubgraph) => void): ISubgraph;
+  /**
+   * Create anonymous subgraphs and and adapt the attributes.
+   *
+   * By specifying a callback function, the target subgraph can be received and manipulated as an argument.
+   *
+   * ```ts
+   * const G = digraph('G', (g) => {
+   *   // Create a anonymous cluster and specifying its attributes.
+   *   g.subgraph({ [attribute.color]: 'red', [attribute.label]: 'my label' }, (A) => {
+   *     // Create a node with id as A1 in anonymous cluster.
+   *     A.node('A1');
+   *   });
+   * });
+   *
+   * console.log(toDot(G));
+   * // digraph "G" {
+   * //   subgraph {
+   * //     color = "red";
+   * //     label = "my label";
+   * //     "A1";
+   * //   }
+   * // }
+   * ```
+   *
+   * @param attributes Object of attributes to be adapted to the subgraph.
+   * @param callback Callbacks for manipulating created or retrieved subgraph.
+   */
+  public subgraph(attributes: ClusterSubgraphAttributes, callback?: (subgraph: ISubgraph) => void): ISubgraph;
+  /**
+   * Create anonymous subgraphs and manipulate them with callback functions.
+   *
+   * By specifying a callback function, the target subgraph can be received and manipulated as an argument.
+   *
+   * @param callback Callbacks for manipulating created or retrieved subgraph.
+   */
   public subgraph(callback?: (subgraph: ISubgraph) => void): ISubgraph;
   public subgraph(...args: unknown[]): ISubgraph {
     const id = args.find((arg: unknown): arg is string => typeof arg === 'string');
@@ -234,7 +311,7 @@ export abstract class Cluster<T extends string> extends AttributesBase<T> implem
     const callback = args.find((arg: unknown): arg is (subgraph: ISubgraph) => void => typeof arg === 'function');
     const subgraph: ISubgraph = id ? this.getSubgraph(id) ?? this.createSubgraph(id) : this.createSubgraph();
     if (attributes !== undefined) {
-      this.apply(attributes);
+      subgraph.apply(attributes);
     }
     if (callback !== undefined) {
       callback(subgraph);
@@ -243,46 +320,206 @@ export abstract class Cluster<T extends string> extends AttributesBase<T> implem
   }
 
   /**
-   * Declarative API for Node.
+   * Create a node by specifying its id (or get it if it already exists).
    *
-   * @description
-   * If there is a Node with the given ID, use it.
-   * If not, create a Node.
+   * By specifying a callback function, the target node can be received and manipulated as an argument.
+   *
+   * ```ts
+   * const G = digraph('G', (g) => {
+   *   // Create a node with id as A.
+   *   g.node('A');
+   * });
+   *
+   * console.log(toDot(G));
+   * // digraph "G" {
+   * //   "A";
+   * // }
+   * ```
    *
    * @param id Node ID.
-   * @param callback Callback to operate Node.
+   * @param callback Callbacks for manipulating created or retrieved node.
    */
   public node(id: string, callback?: (node: INode) => void): INode;
-  public node(id: string, attributes?: NodeAttributes, callback?: (node: INode) => void): INode;
-  public node(id: string, ...args: unknown[]): INode {
-    const attributes = args.find((arg: unknown): arg is NodeAttributes => typeof arg === 'object' && arg !== null);
-    const callback = args.find((arg: unknown): arg is (node: INode) => void => typeof arg === 'function');
-    const node = this.getNode(id) ?? this.createNode(id);
-    if (attributes !== undefined) {
-      node.attributes.apply(attributes);
+  /**
+   * Create a node (or get one if it already exists) and adapt the attributes.
+   *
+   * By specifying a callback function, the target node can be received and manipulated as an argument.
+   *
+   * ```ts
+   * const G = digraph('G', (g) => {
+   *   // Create a node by specifying its id and specifying its attributes.
+   *   g.node('A', {
+   *     [attribute.color]: 'red',
+   *     [attribute.label]: 'my label',
+   *   });
+   * });
+   *
+   * console.log(toDot(G));
+   * // digraph "G" {
+   * //   "A" [
+   * //     color = "red",
+   * //     label = "my label",
+   * //   ];
+   * // }
+   * ```
+   *
+   * @param id Node ID.
+   * @param attributes Object of attributes to be adapted to the node.
+   * @param callback Callbacks for manipulating created or retrieved node.
+   */
+  public node(id: string, attributes: NodeAttributes, callback?: (node: INode) => void): INode;
+  /**
+   * Set a common attribute for the nodes in the cluster.
+   *
+   * ```ts
+   * const G = digraph('G', (g) => {
+   *   // Set a common attribute for the nodes in the cluster.
+   *   g.node({
+   *     [attribute.color]: 'red',
+   *     [attribute.label]: 'my label',
+   *   });
+   * });
+   *
+   * console.log(toDot(G));
+   * // digraph "G" {
+   * //   node [
+   * //     color = "red",
+   * //     label = "my label",
+   * //   ];
+   * // }
+   * ```
+   *
+   * @param attributes Object of attributes to be adapted to the nodes.
+   */
+  public node(attributes: NodeAttributes): void;
+  public node(firstArg: unknown, ...args: unknown[]): INode | void {
+    if (typeof firstArg === 'string') {
+      const id = firstArg;
+      const attributes = args.find((arg: unknown): arg is NodeAttributes => typeof arg === 'object' && arg !== null);
+      const callback = args.find((arg: unknown): arg is (node: INode) => void => typeof arg === 'function');
+      const node = this.getNode(id) ?? this.createNode(id);
+      if (attributes !== undefined) {
+        node.attributes.apply(attributes);
+      }
+      if (callback !== undefined) {
+        callback(node);
+      }
+      return node;
+    } else if (typeof firstArg === 'object' && firstArg !== null) {
+      this.attributes.node.apply(firstArg);
     }
-    if (callback !== undefined) {
-      callback(node);
-    }
-    return node;
   }
 
   /**
-   * Declarative API for Edge.
+   * Create a edge.
    *
-   * @param targets Edges.
-   * @param callback Callback to operate Edge.
+   * By specifying a callback function, the target edge can be received and manipulated as an argument.
+   *
+   * ```ts
+   * const G = digraph('G', (g) => {
+   *   // Create a edge.
+   *   g.edge(['a', 'b']);
+   * });
+   *
+   * console.log(toDot(G));
+   * // digraph "G" {
+   * //   "a" -> "b";
+   * // }
+   * ```
+   * @param targets Nodes.
+   * @param callback Callbacks for manipulating created or retrieved edge.
    */
   public edge(targets: EdgeTargetLike[], callback?: (edge: IEdge) => void): IEdge;
-  public edge(targets: EdgeTargetLike[], attributes?: EdgeAttributes, callback?: (edge: IEdge) => void): IEdge;
-  public edge(targets: EdgeTargetLike[], ...args: unknown[]): IEdge {
-    const attributes = args.find((arg: unknown): arg is EdgeAttributes => typeof arg === 'object');
-    const callback = args.find((arg: unknown): arg is (edge: IEdge) => void => typeof arg === 'function');
-    const edge = this.createEdge(targets, attributes);
-    if (callback !== undefined) {
-      callback(edge);
+  /**
+   * Create a edge and adapt the attributes.
+   *
+   * By specifying a callback function, the target edge can be received and manipulated as an argument.
+   *
+   * ```ts
+   * const G = digraph('G', (g) => {
+   *   // Create a edge and specifying its attributes.
+   *   g.edge(['a', 'b'], {
+   *     [attribute.color]: 'red',
+   *     [attribute.label]: 'my label',
+   *   });
+   * });
+   *
+   * console.log(toDot(G));
+   * // digraph "G" {
+   * //   "a" -> "b" [
+   * //     color = "red",
+   * //     label = "my label",
+   * //   ];
+   * // }
+   * ```
+   *
+   * @param id Node ID.
+   * @param attributes Object of attributes to be adapted to the edge.
+   * @param callback Callbacks for manipulating created or retrieved edge.
+   */
+  public edge(targets: EdgeTargetLike[], attributes: EdgeAttributes, callback?: (edge: IEdge) => void): IEdge;
+  /**
+   * Set a common attribute for the edges in the cluster.
+   *
+   *
+   * ```ts
+   * const G = digraph('G', (g) => {
+   *   // Set a common attribute for the edges in the cluster.
+   *   g.edge({
+   *     [attribute.color]: 'red',
+   *     [attribute.label]: 'my label',
+   *   });
+   * });
+   *
+   * console.log(toDot(G));
+   * // digraph "G" {
+   * //   edge [
+   * //     color = "red",
+   * //     label = "my label",
+   * //   ];
+   * // }
+   * ```
+   * @param attributes Object of attributes to be adapted to the edges.
+   */
+  public edge(attributes: EdgeAttributes): void;
+  public edge(firstArg: EdgeTargetLike[] | EdgeAttributes, ...args: unknown[]): IEdge | void {
+    if (Array.isArray(firstArg)) {
+      const targets = [...firstArg];
+      const attributes = args.find((arg: unknown): arg is EdgeAttributes => typeof arg === 'object');
+      const callback = args.find((arg: unknown): arg is (edge: IEdge) => void => typeof arg === 'function');
+      const edge = this.createEdge(targets, attributes);
+      if (callback !== undefined) {
+        callback(edge);
+      }
+      return edge;
+    } else if (typeof firstArg === 'object' && firstArg !== null) {
+      this.attributes.edge.apply(firstArg);
     }
-    return edge;
+  }
+
+  /**
+   * Set a common attribute for the clusters in the cluster.
+   *
+   * ```ts
+   * const G = digraph('G', (g) => {
+   *   g.graph({
+   *     [attribute.color]: 'red',
+   *     [attribute.label]: 'my label',
+   *   });
+   * });
+   *
+   * console.log(toDot(G));
+   * // digraph "G" {
+   * //   graph [
+   * //     color = "red",
+   * //     label = "my label",
+   * //   ];
+   * // }
+   * ```
+   * @param attributes Object of attributes to be adapted to the clusters.
+   */
+  public graph(attributes: ClusterSubgraphAttributes): void {
+    this.attributes.graph.apply(attributes);
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -192,48 +192,267 @@ export interface ICluster<T extends string = string> extends IHasComment, IAttri
   getNode(id: string): INode | undefined;
   /** Create Edge and add it to the cluster. */
   createEdge(targets: (EdgeTargetLike | EdgeTargetsLike)[], attributes?: EdgeAttributes): IEdge;
+
   /**
-   * Declarative API for Subgraph.
+   * Create a subgraph by specifying its id (or get it if it already exists).
    *
-   * @description
-   * If there is a Subgraph with the given ID, use it.
-   * If not, create a Subgraph.
+   * By specifying a callback function, the target subgraph can be received and manipulated as an argument.
+   *
+   * ```ts
+   * const G = digraph('G', (g) => {
+   *   // Create a cluster with id as A.
+   *   g.subgraph('A', (A) => {
+   *     // Create a node with id as A1 in cluster A.
+   *     A.node('A1');
+   *   });
+   * });
+   *
+   * console.log(toDot(G));
+   * // digraph "G" {
+   * //   subgraph "A" {
+   * //     "A1";
+   * //   }
+   * // }
+   * ```
    *
    * @param id Subgraph ID.
-   * @param attributes Subgraph attributes.
-   * @param callback Callback to operate Subgraph.
+   * @param callback Callbacks for manipulating created or retrieved subgraph.
    */
-  subgraph(id?: string, callback?: (subgraph: ISubgraph) => void): ISubgraph;
-  subgraph(id?: string, attributes?: ClusterSubgraphAttributes, callback?: (subgraph: ISubgraph) => void): ISubgraph;
-  subgraph(attributes?: ClusterSubgraphAttributes, callback?: (subgraph: ISubgraph) => void): ISubgraph;
+  subgraph(id: string, callback?: (subgraph: ISubgraph) => void): ISubgraph;
+  /**
+   * Create a subgraph (or get one if it already exists) and adapt the attributes.
+   *
+   * By specifying a callback function, the target subgraph can be received and manipulated as an argument.
+   *
+   * ```ts
+   * const G = digraph('G', (g) => {
+   *   // Create a cluster with id as A and specifying its attributes.
+   *   g.subgraph('A', { [attribute.color]: 'red', [attribute.label]: 'my label' }, (A) => {
+   *     // Create a node with id as A1 in cluster A.
+   *     A.node('A1');
+   *   });
+   * });
+   *
+   * console.log(toDot(G));
+   * // digraph "G" {
+   * //   subgraph "A" {
+   * //     color = "red";
+   * //     label = "my label";
+   * //     "A1";
+   * //   }
+   * // }
+   * ```
+   *
+   * @param id  Subgraph ID.
+   * @param attributes Object of attributes to be adapted to the subgraph.
+   * @param callback Callbacks for manipulating created or retrieved subgraph.
+   */
+  subgraph(id: string, attributes: ClusterSubgraphAttributes, callback?: (subgraph: ISubgraph) => void): ISubgraph;
+  /**
+   * Create anonymous subgraphs and and adapt the attributes.
+   *
+   * By specifying a callback function, the target subgraph can be received and manipulated as an argument.
+   *
+   * ```ts
+   * const G = digraph('G', (g) => {
+   *   // Create a anonymous cluster and specifying its attributes.
+   *   g.subgraph({ [attribute.color]: 'red', [attribute.label]: 'my label' }, (A) => {
+   *     // Create a node with id as A1 in anonymous cluster.
+   *     A.node('A1');
+   *   });
+   * });
+   *
+   * console.log(toDot(G));
+   * // digraph "G" {
+   * //   subgraph {
+   * //     color = "red";
+   * //     label = "my label";
+   * //     "A1";
+   * //   }
+   * // }
+   * ```
+   *
+   * @param attributes Object of attributes to be adapted to the subgraph.
+   * @param callback Callbacks for manipulating created or retrieved subgraph.
+   */
+  subgraph(attributes: ClusterSubgraphAttributes, callback?: (subgraph: ISubgraph) => void): ISubgraph;
+  /**
+   * Create anonymous subgraphs and manipulate them with callback functions.
+   *
+   * By specifying a callback function, the target subgraph can be received and manipulated as an argument.
+   *
+   * @param callback Callbacks for manipulating created or retrieved subgraph.
+   */
   subgraph(callback?: (subgraph: ISubgraph) => void): ISubgraph;
 
   /**
-   * Declarative API for Node.
+   * Create a node by specifying its id (or get it if it already exists).
    *
-   * @description
-   * If there is a Node with the given ID, use it.
-   * If not, create a Node.
+   * By specifying a callback function, the target node can be received and manipulated as an argument.
+   *
+   * ```ts
+   * const G = digraph('G', (g) => {
+   *   // Create a node with id as A.
+   *   g.node('A');
+   * });
+   *
+   * console.log(toDot(G));
+   * // digraph "G" {
+   * //   "A";
+   * // }
+   * ```
    *
    * @param id Node ID.
-   * @param attributes Node attributes.
-   * @param callback Callback to operate Node.
+   * @param callback Callbacks for manipulating created or retrieved node.
    */
   node(id: string, callback?: (node: INode) => void): INode;
-  node(id: string, attributes?: NodeAttributes, callback?: (node: INode) => void): INode;
   /**
-   * Declarative API for Edge.
+   * Create a node (or get one if it already exists) and adapt the attributes.
    *
-   * @param targets Edges.
-   * @param attributes Edge attributes.
-   * @param callback Callback to operate Edge.
+   * By specifying a callback function, the target node can be received and manipulated as an argument.
+   *
+   * ```ts
+   * const G = digraph('G', (g) => {
+   *   // Create a node by specifying its id and specifying its attributes.
+   *   g.node('A', {
+   *     [attribute.color]: 'red',
+   *     [attribute.label]: 'my label',
+   *   });
+   * });
+   *
+   * console.log(toDot(G));
+   * // digraph "G" {
+   * //   "A" [
+   * //     color = "red",
+   * //     label = "my label",
+   * //   ];
+   * // }
+   * ```
+   *
+   * @param id Node ID.
+   * @param attributes Object of attributes to be adapted to the node.
+   * @param callback Callbacks for manipulating created or retrieved node.
    */
-  edge(targets: (EdgeTargetLike | EdgeTargetsLike)[], callback?: (edge: IEdge) => void): IEdge;
-  edge(
-    targets: (EdgeTargetLike | EdgeTargetsLike)[],
-    attributes?: EdgeAttributes,
-    callback?: (edge: IEdge) => void,
-  ): IEdge;
+  node(id: string, attributes: NodeAttributes, callback?: (node: INode) => void): INode;
+  /**
+   * Set a common attribute for the nodes in the cluster.
+   *
+   * ```ts
+   * const G = digraph('G', (g) => {
+   *   // Set a common attribute for the nodes in the cluster.
+   *   g.node({
+   *     [attribute.color]: 'red',
+   *     [attribute.label]: 'my label',
+   *   });
+   * });
+   *
+   * console.log(toDot(G));
+   * // digraph "G" {
+   * //   node [
+   * //     color = "red",
+   * //     label = "my label",
+   * //   ];
+   * // }
+   * ```
+   *
+   * @param attributes Object of attributes to be adapted to the nodes.
+   */
+  node(attributes: NodeAttributes): void;
+  /**
+   * Create a edge.
+   *
+   * By specifying a callback function, the target edge can be received and manipulated as an argument.
+   *
+   * ```ts
+   * const G = digraph('G', (g) => {
+   *   // Create a edge.
+   *   g.edge(['a', 'b']);
+   * });
+   *
+   * console.log(toDot(G));
+   * // digraph "G" {
+   * //   "a" -> "b";
+   * // }
+   * ```
+   * @param targets Nodes.
+   * @param callback Callbacks for manipulating created or retrieved edge.
+   */
+  edge(targets: EdgeTargetLike[], callback?: (edge: IEdge) => void): IEdge;
+  /**
+   * Create a edge and adapt the attributes.
+   *
+   * By specifying a callback function, the target edge can be received and manipulated as an argument.
+   *
+   * ```ts
+   * const G = digraph('G', (g) => {
+   *   // Create a edge and specifying its attributes.
+   *   g.edge(['a', 'b'], {
+   *     [attribute.color]: 'red',
+   *     [attribute.label]: 'my label',
+   *   });
+   * });
+   *
+   * console.log(toDot(G));
+   * // digraph "G" {
+   * //   "a" -> "b" [
+   * //     color = "red",
+   * //     label = "my label",
+   * //   ];
+   * // }
+   * ```
+   *
+   * @param id Node ID.
+   * @param attributes Object of attributes to be adapted to the edge.
+   * @param callback Callbacks for manipulating created or retrieved edge.
+   */
+  edge(targets: EdgeTargetLike[], attributes: EdgeAttributes, callback?: (edge: IEdge) => void): IEdge;
+  /**
+   * Set a common attribute for the edges in the cluster.
+   *
+   *
+   * ```ts
+   * const G = digraph('G', (g) => {
+   *   // Set a common attribute for the edges in the cluster.
+   *   g.edge({
+   *     [attribute.color]: 'red',
+   *     [attribute.label]: 'my label',
+   *   });
+   * });
+   *
+   * console.log(toDot(G));
+   * // digraph "G" {
+   * //   edge [
+   * //     color = "red",
+   * //     label = "my label",
+   * //   ];
+   * // }
+   * ```
+   * @param attributes Object of attributes to be adapted to the edges.
+   */
+  edge(attributes: EdgeAttributes): void;
+
+  /**
+   * Set a common attribute for the clusters in the cluster.
+   *
+   * ```ts
+   * const G = digraph('G', (g) => {
+   *   g.graph({
+   *     [attribute.color]: 'red',
+   *     [attribute.label]: 'my label',
+   *   });
+   * });
+   *
+   * console.log(toDot(G));
+   * // digraph "G" {
+   * //   graph [
+   * //     color = "red",
+   * //     label = "my label",
+   * //   ];
+   * // }
+   * ```
+   * @param attributes Object of attributes to be adapted to the clusters.
+   */
+  graph(attributes: ClusterSubgraphAttributes): void;
 }
 
 export interface ISubgraph extends ICluster<attribute.Subgraph | attribute.ClusterSubgraph> {


### PR DESCRIPTION
### What was a problem

The API for specifying common attributes for objects in a cluster was not intuitive.

see #252

### How this PR fixes the problem

Added an API for specifying common attributes for objects in a cluster, so that common attributes can be set in the same way as in the dot language.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

Updated documentation to avoid confusion on usage since we are using overload.
