### PR TITLE
add exports field for ESModule

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,11 @@
     "type": "github",
     "url": "https://github.com/sponsors/kamiazya"
   },
-  "main": "lib/index.js",
-  "module": "lib/index.mjs",
+  "main": "./lib/index.js",
+  "exports": {
+    "import": "./lib/index.mjs",
+    "require": "./lib/index.js"
+  },
   "unpkg": "lib/bundle.min.js",
   "types": "lib/index.d.ts",
   "license": "MIT",


### PR DESCRIPTION
<!-- Thank you for your contribution to ts-graphviz! Please replace {Please write here} with your description -->

### What was a problem

When Node.js supports ESModule, it is now set in the `exports` field instead of the `module` field in package.json.

Since this module uses the `module` field, there was a problem that ESModule could not be used.

### How this PR fixes the problem

Fixed to use exports field.

### Additional Comments (if any)

https://nodejs.org/api/packages.html
