### PR TITLE
fix: fix EdgePlugin for NodeRefGroup to AST conversion

### DIFF
--- a/src/ast/model-shim/from-model/plugins/EdgePlugin.ts
+++ b/src/ast/model-shim/from-model/plugins/EdgePlugin.ts
@@ -63,6 +63,63 @@ export const EdgePlugin: ConvertFromModelPlugin<EdgeModel> = {
               },
               [],
             );
+          } else {
+            return createElement(
+              'NodeRefGroup',
+              {},
+              target.map((n) => {
+                if (isNodeModel(n)) {
+                  return createElement(
+                    'NodeRef',
+                    {
+                      id: createElement(
+                        'Literal',
+                        {
+                          value: n.id,
+                          quoted: true,
+                        },
+                        [],
+                      ),
+                    },
+                    [],
+                  );
+                }
+                return createElement(
+                  'NodeRef',
+                  {
+                    id: createElement(
+                      'Literal',
+                      {
+                        value: n.id,
+                        quoted: true,
+                      },
+                      [],
+                    ),
+                    port: n.port
+                      ? createElement(
+                          'Literal',
+                          {
+                            value: n.port,
+                            quoted: true,
+                          },
+                          [],
+                        )
+                      : undefined,
+                    compass: n.compass
+                      ? createElement(
+                          'Literal',
+                          {
+                            value: n.compass,
+                            quoted: true,
+                          },
+                          [],
+                        )
+                      : undefined,
+                  },
+                  [],
+                );
+              }),
+            );
           }
         }) as [from: EdgeTargetASTNode, to: EdgeTargetASTNode, ...rest: EdgeTargetASTNode[]],
       },

--- a/test/edge-group.test.ts
+++ b/test/edge-group.test.ts
@@ -1,0 +1,96 @@
+import { digraph } from 'ts-graphviz';
+import { fromModel } from 'ts-graphviz/ast';
+
+import { toDot } from '#test/utils';
+
+test('edge group', () => {
+  expect(
+    fromModel(
+      digraph((g) => {
+        g.edge(['a', ['b', 'c']]);
+      }),
+    ),
+  ).toMatchInlineSnapshot(`
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "location": null,
+              "targets": Array [
+                Object {
+                  "children": Array [],
+                  "compass": undefined,
+                  "id": Object {
+                    "children": Array [],
+                    "location": null,
+                    "quoted": true,
+                    "type": "Literal",
+                    "value": "a",
+                  },
+                  "location": null,
+                  "port": undefined,
+                  "type": "NodeRef",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [],
+                      "compass": undefined,
+                      "id": Object {
+                        "children": Array [],
+                        "location": null,
+                        "quoted": true,
+                        "type": "Literal",
+                        "value": "b",
+                      },
+                      "location": null,
+                      "port": undefined,
+                      "type": "NodeRef",
+                    },
+                    Object {
+                      "children": Array [],
+                      "compass": undefined,
+                      "id": Object {
+                        "children": Array [],
+                        "location": null,
+                        "quoted": true,
+                        "type": "Literal",
+                        "value": "c",
+                      },
+                      "location": null,
+                      "port": undefined,
+                      "type": "NodeRef",
+                    },
+                  ],
+                  "location": null,
+                  "type": "NodeRefGroup",
+                },
+              ],
+              "type": "Edge",
+            },
+          ],
+          "directed": true,
+          "id": undefined,
+          "location": null,
+          "strict": false,
+          "type": "Graph",
+        },
+      ],
+      "location": null,
+      "type": "Dot",
+    }
+  `);
+  expect(
+    toDot(
+      digraph((g) => {
+        g.edge(['a', ['b', 'c']]);
+      }),
+    ),
+  ).toMatchInlineSnapshot(`
+    digraph {
+      "a" -> {"b" "c"};
+    }
+  `);
+});


### PR DESCRIPTION
<!-- Thank you for your contribution to ts-graphviz! Please replace {Please write here} with your description -->

### What was a problem

The conversion failed when specifying a NodeRefGroup for the following Edge target.

```ts
digraph((g) => {
  g.edge(['a', ['b', 'c']]);
});
```

### How this PR fixes the problem

EdgePlugin of FromModelConverter was modified to allow conversion of NodeRefGroup.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

It can be converted as follows.

```dot
digraph {
  "a" -> {"b" "c"};
}
```