### PR TITLE
Support old version TypeScrpt

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -30,8 +30,12 @@ jobs:
       run: yarn build
       env:
         CI: 'true'
-    - name: Test
+    - name: Unit Test
       run: yarn test
+      env:
+        CI: 'true'
+    - name: E2E Test
+      run: yarn --cwd e2e test
       env:
         CI: 'true'
 

--- a/.npmignore
+++ b/.npmignore
@@ -12,6 +12,7 @@ CODE_OF_CONDUCT.md
 CONTRIBUTING.md
 coverage
 doc
+e2e
 jest.config.json
 LICENSE
 Makefile
@@ -19,6 +20,7 @@ media/*.dot
 README.ja.md
 rollup.config.js
 src
+test
 tsconfig.build.json
 tsconfig.json
 typedoc.json

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,1 @@
+yarn.lock

--- a/e2e/envs/cjs/package.json
+++ b/e2e/envs/cjs/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "cjs",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "test": "node sample.js"
+  },
+  "dependencies": {
+    "ts-graphviz": "file:../../ts-graphviz.tgz"
+  }
+}

--- a/e2e/envs/cjs/sample.js
+++ b/e2e/envs/cjs/sample.js
@@ -1,0 +1,20 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { attribute: _, Digraph, Subgraph, Node, Edge, toDot } = require('ts-graphviz');
+
+const G = new Digraph();
+const A = new Subgraph('A');
+const node1 = new Node('node1', {
+  [_.color]: 'red',
+});
+const node2 = new Node('node2', {
+  [_.color]: 'blue',
+});
+const edge = new Edge([node1, node2], {
+  [_.label]: 'Edge Label',
+  [_.color]: 'pink',
+});
+G.addSubgraph(A);
+A.addNode(node1);
+A.addNode(node2);
+A.addEdge(edge);
+toDot(G);

--- a/e2e/envs/esm/package.json
+++ b/e2e/envs/esm/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "esm",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node sample.js"
+  },
+  "dependencies": {
+    "ts-graphviz": "file:../../ts-graphviz.tgz"
+  }
+}

--- a/e2e/envs/esm/sample.js
+++ b/e2e/envs/esm/sample.js
@@ -1,0 +1,19 @@
+import { attribute as _, Digraph, Subgraph, Node, Edge, toDot } from 'ts-graphviz';
+
+const G = new Digraph();
+const A = new Subgraph('A');
+const node1 = new Node('node1', {
+  [_.color]: 'red',
+});
+const node2 = new Node('node2', {
+  [_.color]: 'blue',
+});
+const edge = new Edge([node1, node2], {
+  [_.label]: 'Edge Label',
+  [_.color]: 'pink',
+});
+G.addSubgraph(A);
+A.addNode(node1);
+A.addNode(node2);
+A.addEdge(edge);
+toDot(G);

--- a/e2e/envs/ts/package.json
+++ b/e2e/envs/ts/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ts",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "test": "tsc"
+  },
+  "dependencies": {
+    "ts-graphviz": "file:../../ts-graphviz.tgz"
+  },
+  "devDependencies": {
+    "typescript": "*"
+  }
+}

--- a/e2e/envs/ts/src/sample.ts
+++ b/e2e/envs/ts/src/sample.ts
@@ -1,0 +1,46 @@
+import { attribute as _, digraph, toDot } from 'ts-graphviz';
+
+const G = digraph('G', (g) => {
+  const a = g.node('aa');
+  const b = g.node('bb');
+  const c = g.node('cc');
+  g.edge([a, b, c], {
+    [_.color]: 'red',
+  });
+  g.subgraph('A', (A) => {
+    const Aa = A.node('Aaa', {
+      [_.color]: 'pink',
+    });
+
+    const Ab = A.node('Abb', {
+      [_.color]: 'violet',
+    });
+    const Ac = A.node('Acc');
+    A.edge([Aa.port('a'), Ab, Ac, 'E'], {
+      [_.color]: 'red',
+    });
+  });
+});
+
+const dot = toDot(G);
+console.log(dot);
+// digraph "G" {
+//   "aa";
+//   "bb";
+//   "cc";
+//   subgraph "A" {
+//     "Aaa" [
+//       color = "pink",
+//     ];
+//     "Abb" [
+//       color = "violet",
+//     ];
+//     "Acc";
+//     "Aaa":"a" -> "Abb" -> "Acc" -> "E" [
+//       color = "red",
+//     ];
+//   }
+//   "aa" -> "bb" -> "cc" [
+//     color = "red",
+//   ];
+// }

--- a/e2e/envs/ts/tsconfig.json
+++ b/e2e/envs/ts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "types": []
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/e2e/envs/ts3.9/package.json
+++ b/e2e/envs/ts3.9/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ts3.9",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "test": "tsc"
+  },
+  "dependencies": {
+    "ts-graphviz": "file:../../ts-graphviz.tgz"
+  },
+  "devDependencies": {
+    "typescript": "3.9"
+  }
+}

--- a/e2e/envs/ts3.9/src/sample.ts
+++ b/e2e/envs/ts3.9/src/sample.ts
@@ -1,0 +1,46 @@
+import { attribute as _, digraph, toDot } from 'ts-graphviz';
+
+const G = digraph('G', (g) => {
+  const a = g.node('aa');
+  const b = g.node('bb');
+  const c = g.node('cc');
+  g.edge([a, b, c], {
+    [_.color]: 'red',
+  });
+  g.subgraph('A', (A) => {
+    const Aa = A.node('Aaa', {
+      [_.color]: 'pink',
+    });
+
+    const Ab = A.node('Abb', {
+      [_.color]: 'violet',
+    });
+    const Ac = A.node('Acc');
+    A.edge([Aa.port('a'), Ab, Ac, 'E'], {
+      [_.color]: 'red',
+    });
+  });
+});
+
+const dot = toDot(G);
+console.log(dot);
+// digraph "G" {
+//   "aa";
+//   "bb";
+//   "cc";
+//   subgraph "A" {
+//     "Aaa" [
+//       color = "pink",
+//     ];
+//     "Abb" [
+//       color = "violet",
+//     ];
+//     "Acc";
+//     "Aaa":"a" -> "Abb" -> "Acc" -> "E" [
+//       color = "red",
+//     ];
+//   }
+//   "aa" -> "bb" -> "cc" [
+//     color = "red",
+//   ];
+// }

--- a/e2e/envs/ts3.9/tsconfig.json
+++ b/e2e/envs/ts3.9/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "target": "ES2015",
+    "module": "ES2015",
+    "moduleResolution": "node",
+    "types": []
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "workspaces": ["envs/*"],
+  "scripts": {
+    "pretest": "rm -f yarn.lock ts-graphviz.tgz && yarn cache clean --all ts-graphviz && yarn --cwd .. build && yarn --cwd .. pack -f ts-graphviz.tgz && yarn install --no-lockfile",
+    "test": "yarn workspaces run test"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
   "types": "lib/ts/index.d.ts",
   "typesVersions": {
     "<=3.9": {
-      "lib/ts/index.d.ts": ["lib/ts3.9/index.d.ts"],
-      "lib/ts/*/index.d.ts": ["lib/ts3.9/*/index.d.ts"]
+      "lib/ts/*": ["lib/ts3.9/*"]
     }
   },
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -20,26 +20,25 @@
     "type": "github",
     "url": "https://github.com/sponsors/kamiazya"
   },
-  "main": "./lib/index.cjs",
-  "module": "./lib/index.js",
-  "types": "lib/index.d.ts",
+  "main": "./lib/js/index.cjs",
+  "module": "./lib/js/index.js",
   "exports": {
     ".": {
-      "import": "./lib/index.js",
-      "require": "./lib/index.cjs",
-      "types": "./lib/index.d.ts"
+      "import": "./lib/js/index.js",
+      "require": "./lib/js/index.cjs",
+      "types": "./lib/ts/index.d.ts"
     },
     "./ast": {
-      "import": "./lib/ast/index.js",
-      "require": "./lib/ast/index.cjs",
-      "types": "./lib/ast/index.d.ts"
+      "import": "./lib/js/ast/index.js",
+      "require": "./lib/js/ast/index.cjs",
+      "types": "./lib/ts/ast/index.d.ts"
     }
   },
-  "imports": {
-    "#lib/*": {
-      "import": "./lib/*/index.js",
-      "require": "./lib/*/index.cjs",
-      "types": "./lib/*/index.d.ts"
+  "types": "lib/ts/index.d.ts",
+  "typesVersions": {
+    "<=3.9": {
+      "lib/ts/index.d.ts": ["lib/ts3.9/index.d.ts"],
+      "lib/ts/*/index.d.ts": ["lib/ts3.9/*/index.d.ts"]
     }
   },
   "license": "MIT",
@@ -48,8 +47,11 @@
   },
   "scripts": {
     "build:peggy": "peggy --plugin ts-pegjs --extra-options-file src/ast/dot-shim/parser/peggy.options.json -o src/ast/dot-shim/parser/_parse.ts src/ast/dot-shim/parser/dot.peggy",
-    "prebuild": "yarn build:peggy",
-    "build": "tsc -p tsconfig.build.json && rollup -c",
+    "prebuild:tsc": "yarn build:peggy",
+    "build:tsc": "tsc -p tsconfig.build.json",
+    "build:rollup": "rollup -c",
+    "build:downlevel-dts:3.9": "downlevel-dts lib/ts lib/ts3.9 --to=3.9",
+    "build": "yarn build:tsc && yarn build:rollup && yarn build:downlevel-dts:3.9",
     "postbuild": "prettier --write ./lib/**/index.{js,cjs,d.ts}",
     "pretest": "yarn build:peggy",
     "test": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest",
@@ -64,6 +66,7 @@
     "@types/jest-specific-snapshot": "^0.5.6",
     "@typescript-eslint/eslint-plugin": "^5.33.0",
     "@typescript-eslint/parser": "^5.33.0",
+    "downlevel-dts": "^0.11.0",
     "eslint": "^8.22.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,15 +13,15 @@ function* createOptions() {
     `../../../../../../${subPackage}/index.js`,
   ]);
   yield {
-    input: './lib/index.js',
+    input: './lib/js/index.js',
     output: [
       {
         format: 'cjs',
-        file: './lib/index.cjs',
+        file: './lib/js/index.cjs',
       },
       {
         format: 'esm',
-        file: './lib/index.js',
+        file: './lib/js/index.js',
       },
     ],
     external: subPackages.map((subPackage) => `./${subPackage}/index.js`),
@@ -29,24 +29,24 @@ function* createOptions() {
 
   for (const subPackage of subPackages) {
     yield {
-      input: `./lib/${subPackage}/index.js`,
+      input: `./lib/js/${subPackage}/index.js`,
       output: [
         {
           format: 'cjs',
-          file: `./lib/${subPackage}/index.cjs`,
+          file: `./lib/js/${subPackage}/index.cjs`,
         },
         {
           format: 'esm',
-          file: `./lib/${subPackage}/index.js`,
+          file: `./lib/js/${subPackage}/index.js`,
         },
       ],
       external: subPackageEntrypoints,
     };
     yield {
-      input: `lib/${subPackage}/index.d.ts`,
+      input: `lib/js/${subPackage}/index.d.ts`,
       plugins: [
         del({
-          targets: [`lib/${subPackage}/**/*`, `!lib/${subPackage}/**/index.*`],
+          targets: [`lib/js/${subPackage}/**/*`, `!lib/js/${subPackage}/**/index.*`],
           hook: 'buildEnd',
         }),
         dts(),
@@ -54,16 +54,16 @@ function* createOptions() {
       output: [
         {
           format: 'esm',
-          file: `lib/${subPackage}/index.d.ts`,
+          file: `lib/ts/${subPackage}/index.d.ts`,
         },
       ],
       external: subPackageEntrypoints,
     };
     yield {
-      input: `./lib/${subPackage}/index.cjs`,
+      input: `./lib/js/${subPackage}/index.cjs`,
       output: {
         format: 'cjs',
-        file: `./lib/${subPackage}/index.cjs`,
+        file: `./lib/js/${subPackage}/index.cjs`,
       },
       external: subPackageEntrypoints,
       plugins: [
@@ -79,10 +79,10 @@ function* createOptions() {
   }
 
   yield {
-    input: './lib/index.d.ts',
+    input: './lib/js/index.d.ts',
     plugins: [
       del({
-        targets: ['lib/*.js', 'lib/**/*.d.ts', '!lib/**/index.{js,d.ts}'],
+        targets: ['lib/*.js', 'lib/**/*.d.ts', '!lib/ts/**/index.{js,d.ts}'],
         hook: 'buildEnd',
       }),
       dts(),
@@ -90,17 +90,17 @@ function* createOptions() {
     output: [
       {
         format: 'esm',
-        file: './lib/index.d.ts',
+        file: './lib/ts/index.d.ts',
       },
     ],
     external: subPackages.map((subPackage) => `./${subPackage}/index.js`),
   };
 
   yield {
-    input: './lib/index.cjs',
+    input: './lib/js/index.cjs',
     output: {
       format: 'cjs',
-      file: './lib/index.cjs',
+      file: './lib/js/index.cjs',
     },
     external: subPackages.map((subPackage) => `./${subPackage}/index.js`),
     plugins: [

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "lib/js"
+  },
   "include": ["src/**/*.ts"],
   "exclude": ["**/*.spec.ts", "**/*.test.ts", "**/__tests__/***/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "strict": true,
     "alwaysStrict": true,
     "strictNullChecks": true,
-    "outDir": "lib",
     "esModuleInterop": true,
     "moduleResolution": "Node16",
     "skipLibCheck": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1555,6 +1555,15 @@ domutils@^2.8.0:
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
 
+downlevel-dts@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/downlevel-dts/-/downlevel-dts-0.11.0.tgz#514a2d723009c5845730c1db6c994484c596ed9c"
+  integrity sha512-vo835pntK7kzYStk7xUHDifiYJvXxVhUapt85uk2AI94gUUAQX9HNRtrcMHNSc3YHJUEHGbYIGsM99uIbgAtxw==
+  dependencies:
+    semver "^7.3.2"
+    shelljs "^0.8.3"
+    typescript next
+
 electron-to-chromium@^1.4.202:
   version "1.4.218"
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.218.tgz"
@@ -2052,7 +2061,7 @@ glob-parent@^6.0.1:
   dependencies:
     is-glob "^4.0.3"
 
-glob@^7.1.3, glob@^7.1.4:
+glob@^7.0.0, glob@^7.1.3, glob@^7.1.4:
   version "7.2.3"
   resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -2215,6 +2224,11 @@ internal-slot@^1.0.3:
     get-intrinsic "^1.1.0"
     has "^1.0.3"
     side-channel "^1.0.4"
+
+interpret@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
+  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -3438,6 +3452,13 @@ react-is@^18.0.0:
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==
+  dependencies:
+    resolve "^1.1.6"
+
 regexp.prototype.flags@^1.4.3:
   version "1.4.3"
   resolved "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz"
@@ -3479,7 +3500,7 @@ resolve.exports@^1.1.0:
   resolved "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz"
   integrity sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==
 
-resolve@^1.20.0, resolve@^1.22.0:
+resolve@^1.1.6, resolve@^1.20.0, resolve@^1.22.0:
   version "1.22.1"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz"
   integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
@@ -3558,6 +3579,15 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+shelljs@^0.8.3:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
+  integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 shiki@^0.11.1:
   version "0.11.1"
@@ -3864,6 +3894,11 @@ typescript@^4.7.4:
   version "4.7.4"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+
+typescript@next:
+  version "5.0.0-dev.20221128"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.0-dev.20221128.tgz#c42cfe49dc7ea504ba778d66fca0dbe681bd432a"
+  integrity sha512-cNV/osEHGNKTyjj/Ivi8s8x7MPkh0Kd/t53QjyXfM3jO3cC2jhL6kor57ziWqvyfl6paWjdNUVO/jxGsQOyfug==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
<!-- Thank you for your contribution to ts-graphviz! Please replace {Please write here} with your description -->

### What was a problem

So far the project has used a newer version of TypeScript for development.

This caused problems, such as builds failing with previous versions that did not support the new syntax for type definitions.

Therefore, it was necessary to take measures such as applying a patch to specify the typesVersion on the project side as shown below.  

https://github.com/aws/aws-prototyping-sdk/blob/d2593f99dd238029f6f581a1b65c414d42e89b78/packages/cdk-graph-plugin-diagram/scripts/patch-ts-graphvis.ts


### How this PR fixes the problem

Provides TypeScript 3.9 types that have been proven to be used separately from the type definitions of the latest version of typescript.

In addition, a mechanism was established to perform E2E testing of npm packages to check the behavior of typesVersions.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)
