### PR TITLE
fix: fix for deno e2e test failed

### DIFF
--- a/src/adapter/deno/mod.js
+++ b/src/adapter/deno/mod.js
@@ -24,11 +24,22 @@ export async function toStream(dot, options) {
   return cp.stdout;
 }
 
+function open(path) {
+  try {
+    return Deno.open(path, { write: true });
+  } catch (e) {
+    if (e instanceof Deno.errors.NotFound) {
+      return Deno.open(path, { createNew: true, write: true });
+    }
+    throw e;
+  }
+}
+
 /**
  * Execute the Graphviz dot command and output the results to a file.
  */
 export async function toFile(dot, path, options) {
-  const output = await Deno.open(path, { createNew: true, write: true });
+  const output = await open(path);
   const stream = await toStream(dot, options);
   await stream.pipeTo(output.writable);
 }

--- a/src/adapter/deno/mod.js
+++ b/src/adapter/deno/mod.js
@@ -16,6 +16,7 @@ export async function toStream(dot, options) {
   const cp = new Deno.Command(command, {
     args: args,
     stdin: 'piped',
+    stdout: 'piped',
   }).spawn();
   const stdin = cp.stdin.getWriter();
   await stdin.write(new TextEncoder().encode(dot));
@@ -27,7 +28,7 @@ export async function toStream(dot, options) {
  * Execute the Graphviz dot command and output the results to a file.
  */
 export async function toFile(dot, path, options) {
-  const output = await Deno.open(path, { write: true });
+  const output = await Deno.open(path, { createNew: true, write: true });
   const stream = await toStream(dot, options);
   await stream.pipeTo(output.writable);
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to ts-graphviz! Please replace {Please write here} with your description -->

### What was a problem

Uncaught TypeError: stdout is not piped" error on Deno's E2E test.

Some investigation was done and fixed.

JOB: https://github.com/ts-graphviz/ts-graphviz/actions/runs/3815332614/jobs/6490249871#step:10:464

### How this PR fixes the problem

- Specified stdout as piped in deno.Command.
- Fixed behavior in case of missing files.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)
