### PR TITLE
Rename AttributeList kinds to lowercase

### DIFF
--- a/src/ast/dot-shim/printer/stringify.test.ts
+++ b/src/ast/dot-shim/printer/stringify.test.ts
@@ -58,7 +58,7 @@ describe('stringify', () => {
       expect(
         stringify({
           type: 'AttributeList',
-          kind: 'Node',
+          kind: 'node',
           children: [],
         }),
       ).toMatchInlineSnapshot(`node [];`);
@@ -68,7 +68,7 @@ describe('stringify', () => {
       expect(
         stringify({
           type: 'AttributeList',
-          kind: 'Edge',
+          kind: 'edge',
           children: [],
         }),
       ).toMatchInlineSnapshot(`edge [];`);
@@ -78,7 +78,7 @@ describe('stringify', () => {
       expect(
         stringify({
           type: 'AttributeList',
-          kind: 'Graph',
+          kind: 'graph',
           children: [],
         }),
       ).toMatchInlineSnapshot(`graph [];`);
@@ -88,7 +88,7 @@ describe('stringify', () => {
       expect(
         stringify({
           type: 'AttributeList',
-          kind: 'Node',
+          kind: 'node',
           children: [
             {
               type: 'Attribute',
@@ -120,7 +120,7 @@ describe('stringify', () => {
       expect(
         stringify({
           type: 'AttributeList',
-          kind: 'Node',
+          kind: 'node',
           children: [
             {
               type: 'Attribute',

--- a/src/ast/model-shim/to-model/plugins/utils/apply-statments.ts
+++ b/src/ast/model-shim/to-model/plugins/utils/apply-statments.ts
@@ -43,13 +43,13 @@ export function applyStatements(graph: GraphBaseModel, statements: ClusterStatem
           .filter<AttributeASTNode>((v): v is AttributeASTNode => v.type === 'Attribute')
           .reduce((prev, curr) => ({ ...prev, [curr.key.value]: curr.value.value }), {});
         switch (stmt.kind) {
-          case 'Edge':
+          case 'edge':
             graph.edge(attrs);
             break;
-          case 'Node':
+          case 'node':
             graph.node(attrs);
             break;
-          case 'Graph':
+          case 'graph':
             graph.graph(attrs);
             break;
         }

--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -94,7 +94,7 @@ export interface AttributeASTPropaties<T extends AttributeKey = AttributeKey> ex
  * @group AST
  */
 export interface AttributeListASTPropaties extends ASTCommonPropaties {
-  kind: 'Graph' | 'Edge' | 'Node';
+  kind: 'graph' | 'edge' | 'node';
 }
 
 /**

--- a/src/common/models.ts
+++ b/src/common/models.ts
@@ -185,7 +185,7 @@ export interface AttributesGroupModel<T extends AttributeKey> extends Attributes
 /**
  * @group Models
  */
-export type AttributeListKind = 'Graph' | 'Edge' | 'Node';
+export type AttributeListKind = 'graph' | 'edge' | 'node';
 
 /**
  * A list object of attributes commonly specified for nodes, subgraphs, and edges
@@ -238,11 +238,11 @@ export interface EdgeModel extends HasComment, HasAttributes<EdgeAttributeKey>, 
  */
 export interface GraphCommonAttributes {
   /** Manage common attributes of graphs in a graph. */
-  graph: AttributeListModel<'Graph', SubgraphAttributeKey | ClusterSubgraphAttributeKey>;
+  graph: AttributeListModel<'graph', SubgraphAttributeKey | ClusterSubgraphAttributeKey>;
   /** Manage common attributes of edges in a graph. */
-  edge: AttributeListModel<'Edge', EdgeAttributeKey>;
+  edge: AttributeListModel<'edge', EdgeAttributeKey>;
   /** Manage common attributes of nodes in a graph. */
-  node: AttributeListModel<'Node', NodeAttributeKey>;
+  node: AttributeListModel<'node', NodeAttributeKey>;
 }
 
 /**

--- a/src/core/models/AttributeList.spec.ts
+++ b/src/core/models/AttributeList.spec.ts
@@ -6,7 +6,7 @@ import { AttributeListKind } from '../../common/index.js';
 
 let attrs: AttributeList<AttributeListKind>;
 beforeEach(() => {
-  attrs = new AttributeList('Node');
+  attrs = new AttributeList('node');
 });
 
 describe('object', () => {
@@ -27,14 +27,14 @@ describe('object', () => {
 
 describe('constructor', () => {
   describe('1st argument is kind of AttributeList', () => {
-    test.each(['Node', 'Edge', 'Graph'] as AttributeListKind[])('AttributeList kind is %s', (kind) => {
+    test.each(['node', 'edge', 'graph'] as AttributeListKind[])('AttributeList kind is %s', (kind) => {
       attrs = new AttributeList(kind);
       expect(attrs.$$kind).toStrictEqual(kind);
     });
   });
 
   test('2nd argument is attribute object', () => {
-    attrs = new AttributeList('Node', {
+    attrs = new AttributeList('node', {
       [_.label]: 'Label',
     });
     expect(attrs.size).toBe(1);

--- a/src/core/models/GraphBase.ts
+++ b/src/core/models/GraphBase.ts
@@ -37,9 +37,9 @@ export abstract class GraphBase<T extends AttributeKey> extends AttributesBase<T
   public comment?: string;
 
   public readonly attributes: Readonly<GraphCommonAttributes> = Object.freeze({
-    graph: new AttributeList<'Graph', SubgraphAttributeKey | ClusterSubgraphAttributeKey>('Graph'),
-    edge: new AttributeList<'Edge', EdgeAttributeKey>('Edge'),
-    node: new AttributeList<'Node', NodeAttributeKey>('Node'),
+    graph: new AttributeList<'graph', SubgraphAttributeKey | ClusterSubgraphAttributeKey>('graph'),
+    edge: new AttributeList<'edge', EdgeAttributeKey>('edge'),
+    node: new AttributeList<'node', NodeAttributeKey>('node'),
   });
 
   get nodes(): ReadonlyArray<NodeModel> {


### PR DESCRIPTION
<!-- Thank you for your contribution to ts-graphviz! Please replace {Please write here} with your description -->

### What was a problem

Fixes #756 

### How this PR fixes the problem

Renames the kind constants to lowercase

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)

### Additional Comments (if any)
