### PR TITLE
Add more options for adapter module

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,10 +84,10 @@
   "scripts": {
     "build:peggy": "peggy --plugin ts-pegjs --extra-options-file src/ast/dot-shim/parser/peggy.options.json -o src/ast/dot-shim/parser/_parse.ts src/ast/dot-shim/parser/dot.peggy",
     "prebuild": "yarn build:peggy",
-    "build:deno": "cp -r src/adapter/deno lib/adapter/deno",
+    "build:deno": "mkdir -p lib/adapter/deno && cp -r src/adapter/deno/* lib/adapter/deno && sed -i \"s/index.ts/index.js/g\" lib/adapter/deno/mod.js && sed -i \"s/index.ts/index.d.ts/g\" lib/adapter/deno/mod.d.ts",
     "build:node": "tsc -p tsconfig.build.json && rollup -c",
     "build": "yarn build:node && yarn build:deno",
-    "postbuild": "prettier --write ./lib/**/index.{js,cjs,d.ts}",
+    "postbuild": "prettier --write ./lib/**/*.{js,cjs,d.ts}",
     "pretest": "yarn build:peggy",
     "test": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest",
     "format": "eslint --ext ts src --fix && prettier --write './**/*.{ts,js,json,yaml}' '!lib'",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,15 +3,27 @@ import dts from 'rollup-plugin-dts';
 import replace from '@rollup/plugin-replace';
 
 function* createOptions() {
-  const subPackages = ['utils', 'common', 'ast', 'core', 'adapter/node', 'adapter/browser'];
-  const subPackageEntrypoints = subPackages.flatMap((subPackage) => [
-    `../${subPackage}/index.js`,
-    `../../${subPackage}/index.js`,
-    `../../../${subPackage}/index.js`,
-    `../../../../${subPackage}/index.js`,
-    `../../../../../${subPackage}/index.js`,
-    `../../../../../../${subPackage}/index.js`,
-  ]);
+  const subPackages = [
+    'utils',
+    'common',
+    'ast',
+    'core',
+    'adapter/types',
+    'adapter/utils',
+    'adapter/node',
+    'adapter/browser',
+  ];
+  const subPackageEntrypoints = subPackages.flatMap((subPackage) => {
+    const pkg = subPackage.startsWith('adapter/') ? subPackage.slice('adapter/'.length) : subPackage;
+    return [
+      `../${pkg}/index.js`,
+      `../../${pkg}/index.js`,
+      `../../../${pkg}/index.js`,
+      `../../../../${pkg}/index.js`,
+      `../../../../../${pkg}/index.js`,
+      `../../../../../../${pkg}/index.js`,
+    ];
+  });
   yield {
     input: './lib/index.js',
     output: [

--- a/src/adapter/deno/mod.d.ts
+++ b/src/adapter/deno/mod.d.ts
@@ -1,17 +1,13 @@
-export type Format = 'png' | 'svg' | 'json' | 'jpg' | 'pdf' | 'xdot' | 'plain' | 'dot_json';
-
-export interface Options {
-  format?: Format;
-  suppressWarnings?: boolean;
-  dotCommand?: string;
-}
+import { Options, Format, Layout } from '../types/index.ts';
 
 /**
  * Execute the Graphviz dot command and make a Stream of the results.
  */
-export function toStream(dot: string, options?: Options): Promise<ReadableStream<Uint8Array>>;
+export function toStream<T extends Layout>(dot: string, options?: Options<T>): Promise<ReadableStream<Uint8Array>>;
 
 /**
  * Execute the Graphviz dot command and output the results to a file.
  */
-export function toFile(dot: string, path: string, options?: Options): Promise<void>;
+export function toFile<T extends Layout>(dot: string, path: string, options?: Options<T>): Promise<void>;
+
+export { Options, Format, Layout };

--- a/src/adapter/deno/mod.js
+++ b/src/adapter/deno/mod.js
@@ -1,13 +1,4 @@
-function commandBuilder({ dotCommand = 'dot', suppressWarnings = true, format = 'svg' } = {}) {
-  const args = [
-    ...(function* () {
-      if (suppressWarnings) yield '-q';
-      yield `-T${format}`;
-    })(),
-  ];
-  return [dotCommand, args];
-}
-
+import { commandBuilder } from '../utils/index.ts';
 /**
  * Execute the Graphviz dot command and make a Stream of the results.
  */

--- a/src/adapter/node/index.ts
+++ b/src/adapter/node/index.ts
@@ -2,53 +2,6 @@
  * @module ts-graphviz/adapter
  * @beta
  */
-import { createWriteStream } from 'node:fs';
-import { Readable, pipeline as _pipeline } from 'node:stream';
-import { promisify } from 'node:util';
-import { spawn } from 'node:child_process';
-
-export type Format = 'png' | 'svg' | 'json' | 'jpg' | 'pdf' | 'xdot' | 'plain' | 'dot_json';
-
-export interface Options {
-  format?: Format;
-  suppressWarnings?: boolean;
-  dotCommand?: string;
-}
-
-function commandBuilder({ dotCommand = 'dot', suppressWarnings = true, format = 'svg' }: Options = {}): [
-  command: string,
-  args: string[],
-] {
-  const args = [
-    ...(function* () {
-      if (suppressWarnings) yield '-q';
-      yield `-T${format}`;
-    })(),
-  ];
-  return [dotCommand, args];
-}
-
-/**
- * NOTE:
- * The node:stream/promises standard module is not provided in Node 14.
- * Fix Node 14 to use node:stream/promises after LTS ends.
- */
-const pipeline = promisify(_pipeline);
-
-/**
- * Execute the Graphviz dot command and make a Stream of the results.
- */
-export async function toStream(dot: string, options?: Options): Promise<NodeJS.ReadableStream> {
-  const [command, args] = commandBuilder(options);
-  const p = spawn(command, args, { stdio: 'pipe' });
-  await pipeline(Readable.from([dot]), p.stdin);
-  return p.stdout;
-}
-
-/**
- * Execute the Graphviz dot command and output the results to a file.
- */
-export async function toFile(dot: string, path: string, options?: Options): Promise<void> {
-  const stream = await toStream(dot, options);
-  await pipeline(stream, createWriteStream(path));
-}
+export type { Options, Format } from '../types/index.js';
+export * from './to-stream.js';
+export * from './to-file.js';

--- a/src/adapter/node/to-file.ts
+++ b/src/adapter/node/to-file.ts
@@ -1,0 +1,12 @@
+import { createWriteStream } from 'node:fs';
+import { Layout, Options } from '../types/index.js';
+import { toStream } from './to-stream.js';
+import { pipeline } from './utils.js';
+
+/**
+ * Execute the Graphviz dot command and output the results to a file.
+ */
+export async function toFile<T extends Layout>(dot: string, path: string, options?: Options<T>): Promise<void> {
+  const stream = await toStream(dot, options);
+  await pipeline(stream, createWriteStream(path));
+}

--- a/src/adapter/node/to-stream.ts
+++ b/src/adapter/node/to-stream.ts
@@ -1,0 +1,15 @@
+import { Readable } from 'node:stream';
+import { spawn } from 'node:child_process';
+import { Layout, Options } from '../types/index.js';
+import { commandBuilder } from '../utils/index.js';
+import { pipeline } from './utils.js';
+
+/**
+ * Execute the Graphviz dot command and make a Stream of the results.
+ */
+export async function toStream<T extends Layout>(dot: string, options?: Options<T>): Promise<NodeJS.ReadableStream> {
+  const [command, args] = commandBuilder(options ?? {});
+  const p = spawn(command, args, { stdio: 'pipe' });
+  await pipeline(Readable.from([dot]), p.stdin);
+  return p.stdout;
+}

--- a/src/adapter/node/utils.ts
+++ b/src/adapter/node/utils.ts
@@ -1,0 +1,9 @@
+import { pipeline as _pipeline } from 'node:stream';
+import { promisify } from 'node:util';
+
+/**
+ * NOTE:
+ * The node:stream/promises standard module is not provided in Node 14.
+ * Fix Node 14 to use node:stream/promises after LTS ends.
+ */
+export const pipeline = promisify(_pipeline);

--- a/src/adapter/types/index.ts
+++ b/src/adapter/types/index.ts
@@ -1,0 +1,112 @@
+import {
+  EdgeAttributesObject,
+  GraphAttributesObject,
+  NodeAttributesObject,
+  SubgraphAttributesObject,
+} from '../../common/index.js';
+
+export type Format = 'png' | 'svg' | 'json' | 'jpg' | 'pdf' | 'xdot' | 'plain' | 'dot_json';
+
+export type Layout = 'dot' | 'neato' | 'fdp' | 'sfdp' | 'circo' | 'twopi' | 'nop' | 'nop2' | 'osage' | 'patchwork';
+
+export interface NeatoOptions {
+  layout: 'neato';
+  /**
+   * Sets no-op flag in neato.
+   */
+  noop?: number;
+  /**
+   * Reduce graph.
+   */
+  reduce?: boolean;
+}
+
+export interface FdpOptions {
+  layout: 'fdp';
+  /**
+   * Use grid.
+   *
+   * @default true
+   */
+  grid?: boolean;
+  /**
+   * Use old attractive force
+   *
+   * @default true
+   */
+  oldAttractive?: boolean;
+
+  /**
+   * Set number of iterations.
+   */
+  iterations?: number;
+  /**
+   * Set unscaled factor
+   */
+  unscaledFactor?: number;
+  /**
+   * Set overlap expansion factor.
+   */
+  overlapExpansionFactor?: number;
+  /**
+   * Set temperature.
+   */
+  temperature?: number;
+}
+
+export interface OtherOptions {
+  /**
+   * Set layout engine.
+   *
+   * @default 'dot'
+   */
+  layout?: Exclude<Layout, 'neato' | 'fdp'>;
+}
+
+export interface CommonOptions {
+  /**
+   * Set output format.
+   *
+   * @default 'svg'
+   */
+  format?: Format;
+  /**
+   * If true, set level of message suppression (=1).
+   *
+   * @default true
+   */
+  suppressWarnings?: boolean;
+  /**
+   * Path of graphviz dot command.
+   */
+  dotCommand?: string;
+  attributes?: {
+    /**
+     * Set edge attribute.
+     */
+    edge?: EdgeAttributesObject;
+    /**
+     * Set node attribute.
+     */
+    node?: NodeAttributesObject;
+    /**
+     * Set graph attribute.
+     */
+    graph?: GraphAttributesObject & SubgraphAttributesObject;
+  };
+  /**
+   * Scale input
+   */
+  scale?: number;
+  /**
+   * Use external library.
+   */
+  library?: string[];
+  /**
+   * Invert y coordinate in output.
+   */
+  y?: boolean;
+}
+
+export type Options<T extends Layout = Layout> = CommonOptions &
+  (T extends 'neato' ? NeatoOptions : T extends 'fdp' ? FdpOptions : OtherOptions);

--- a/src/adapter/utils/index.ts
+++ b/src/adapter/utils/index.ts
@@ -1,0 +1,52 @@
+import { Layout, Options } from '../types/index.js';
+
+function* args<T extends Layout>(options: Options<T>): Generator<string> {
+  const { suppressWarnings = true, format = 'svg', attributes = {}, library = [], y = false, scale } = options;
+  if (suppressWarnings) yield '-q';
+  yield `-T${format}`;
+  if (attributes.graph) {
+    for (const [key, value] of Object.entries(attributes.graph)) {
+      if (value === true) yield `-G${key}`;
+      else yield `-G${key}="${value}"`;
+    }
+  }
+  if (attributes.node) {
+    for (const [key, value] of Object.entries(attributes.node)) {
+      if (value === true) yield `-N${key}`;
+      else yield `-N${key}="${value}"`;
+    }
+  }
+  if (attributes.edge) {
+    for (const [key, value] of Object.entries(attributes.edge)) {
+      if (value === true) yield `-E${key}`;
+      else yield `-E${key}="${value}"`;
+    }
+  }
+  if (typeof scale === 'number' && !Number.isNaN(scale)) yield `-s${scale}`;
+  if (Array.isArray(library)) for (const lib of library) yield `-l${lib}`;
+  if (y === true) yield `-y`;
+
+  if (typeof options.layout === 'string') {
+    yield `-K${options.layout}`;
+    switch (options.layout) {
+      case 'neato':
+        const { reduce, noop } = options;
+        if (reduce === true) yield '-x';
+        if (typeof noop === 'number') yield `-n${noop}`;
+        break;
+      case 'fdp':
+        const { grid, oldAttractive, iterations, unscaledFactor, overlapExpansionFactor, temperature } = options;
+        yield ['-L', grid ? '' : 'g', oldAttractive ? 'O' : ''].join('');
+        if (typeof iterations === 'number') yield `-Ln${iterations}`;
+        if (typeof unscaledFactor === 'number') yield `-LU${unscaledFactor}`;
+        if (typeof overlapExpansionFactor === 'number') yield `-LC${overlapExpansionFactor}`;
+        if (typeof temperature === 'number') yield `-LT${temperature}`;
+      default:
+        break;
+    }
+  }
+}
+
+export function commandBuilder<T extends Layout>(options: Options<T>): [command: string, args: string[]] {
+  return [options.dotCommand ?? 'dot', Array.from(args(options))];
+}


### PR DESCRIPTION
<!-- Thank you for your contribution to ts-graphviz! Please replace {Please write here} with your description -->

### What was a problem

fix #739 

### How this PR fixes the problem

```ts
export type Format = 'png' | 'svg' | 'json' | 'jpg' | 'pdf' | 'xdot' | 'plain' | 'dot_json';

export type Layout = 'dot' | 'neato' | 'fdp' | 'sfdp' | 'circo' | 'twopi' | 'nop' | 'nop2' | 'osage' | 'patchwork';

export interface NeatoOptions {
  layout: 'neato';
  /**
   * Sets no-op flag in neato.
   */
  noop?: number;
  /**
   * Reduce graph.
   */
  reduce?: boolean;
}

export interface FdpOptions {
  layout: 'fdp';
  /**
   * Use grid.
   *
   * @default true
   */
  grid?: boolean;
  /**
   * Use old attractive force
   *
   * @default true
   */
  oldAttractive?: boolean;

  /**
   * Set number of iterations.
   */
  iterations?: number;
  /**
   * Set unscaled factor
   */
  unscaledFactor?: number;
  /**
   * Set overlap expansion factor.
   */
  overlapExpansionFactor?: number;
  /**
   * Set temperature.
   */
  temperature?: number;
}

export interface OtherOptions {
  /**
   * Set layout engine.
   *
   * @default 'dot'
   */
  layout?: Exclude<Layout, 'neato' | 'fdp'>;
}

export interface CommonOptions {
  /**
   * Set output format.
   *
   * @default 'svg'
   */
  format?: Format;
  /**
   * If true, set level of message suppression (=1).
   *
   * @default true
   */
  suppressWarnings?: boolean;
  /**
   * Path of graphviz dot command.
   */
  dotCommand?: string;
  attributes?: {
    /**
     * Set edge attribute.
     */
    edge?: EdgeAttributesObject;
    /**
     * Set node attribute.
     */
    node?: NodeAttributesObject;
    /**
     * Set graph attribute.
     */
    graph?: GraphAttributesObject & SubgraphAttributesObject;
  };
  /**
   * Scale input
   */
  scale?: number;
  /**
   * Use external library.
   */
  library?: string[];
  /**
   * Invert y coordinate in output.
   */
  y?: boolean;
}

export type Options<T extends Layout = Layout> = CommonOptions &
  (T extends 'neato' ? NeatoOptions : T extends 'fdp' ? FdpOptions : OtherOptions);

/**
 * Execute the Graphviz dot command and make a Stream of the results.
 */
function toStream<T extends Layout>(dot: string, options?: Options<T>): Promise<NodeJS.ReadableStream>;

/**
 * Execute the Graphviz dot command and output the results to a file.
 */
function toFile<T extends Layout>(dot: string, path: string, options?: Options<T>): Promise<void>;

```

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)

### Additional context

With this modification, the Node and Deno command builders have been made common.


