### PR TITLE
Add error handling for adapter module

### DIFF
--- a/src/adapter/node/to-stream.ts
+++ b/src/adapter/node/to-stream.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'node:stream';
+import { Readable, PassThrough } from 'node:stream';
 import { spawn } from 'node:child_process';
 import { Layout, Options } from '../types/index.js';
 import { commandBuilder } from '../utils/index.js';
@@ -9,7 +9,31 @@ import { pipeline } from './utils.js';
  */
 export async function toStream<T extends Layout>(dot: string, options?: Options<T>): Promise<NodeJS.ReadableStream> {
   const [command, args] = commandBuilder(options ?? {});
-  const p = spawn(command, args, { stdio: 'pipe' });
-  await pipeline(Readable.from([dot]), p.stdin);
-  return p.stdout;
+  return new Promise(async function toStreamInternal(resolve, reject) {
+    const p = spawn(command, args, { stdio: 'pipe' });
+
+    // error handling
+    p.on('error', (e) => {
+      reject(
+        new Error(`Command "${command}" failed.\nMESSAGE:${e.message}`, {
+          cause: e,
+        }),
+      );
+    });
+
+    const stderrChunks: Uint8Array[] = [];
+    p.stderr.on('data', (chunk) => stderrChunks.push(chunk));
+
+    const dist = p.stdout.pipe(new PassThrough());
+    p.on('close', async (code, signal) => {
+      if (code === 0) {
+        resolve(dist);
+      } else {
+        const message = Buffer.concat(stderrChunks as ReadonlyArray<Uint8Array>).toString();
+        reject(new Error(`Command "${command}" failed.\nCODE: ${code}\nSIGNAL: ${signal}\nMESSAGE: ${message}`));
+      }
+    });
+
+    await pipeline(Readable.from([dot]), p.stdin);
+  });
 }

--- a/src/adapter/types/index.ts
+++ b/src/adapter/types/index.ts
@@ -5,7 +5,7 @@ import {
   SubgraphAttributesObject,
 } from '../../common/index.js';
 
-export type Format = 'png' | 'svg' | 'json' | 'jpg' | 'pdf' | 'xdot' | 'plain' | 'dot_json';
+export type Format = 'png' | 'svg' | 'json' | 'jpg' | 'pdf' | 'xdot' | 'dot' | 'plain' | 'dot_json';
 
 export type Layout = 'dot' | 'neato' | 'fdp' | 'sfdp' | 'circo' | 'twopi' | 'nop' | 'nop2' | 'osage' | 'patchwork';
 


### PR DESCRIPTION
<!-- Thank you for your contribution to ts-graphviz! Please replace {Please write here} with your description -->

### What was a problem

Exception handling was lax and error details could not be obtained from standard errors.

### How this PR fixes the problem

Standard errors and syscall errors can now be retrieved.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)
