### PR TITLE
fix: rename SyntaxError to let not override native SyntaxError

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "rollup-plugin-dts": "5.1.1",
     "svgo": "^3.0.2",
     "ts-jest": "^29.0.5",
-    "ts-pegjs": "^2.1.0",
+    "ts-pegjs": "^3.0.0",
     "typedoc": "^0.23.15",
     "typescript": "^4.7.4"
   }

--- a/src/ast/dot-shim/parser/__tests__/real-world.test.ts
+++ b/src/ast/dot-shim/parser/__tests__/real-world.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import glob from 'glob';
 import 'jest-specific-snapshot';
 
-import { parse, SyntaxError } from '../_parse.js';
+import { parse, DotSyntaxError } from '../_parse.js';
 
 const dirname = path.dirname(new URL(import.meta.url).pathname);
 
@@ -19,7 +19,7 @@ for (const file of files) {
     try {
       expect(parse(dot)).toMatchSpecificSnapshot(snapshot);
     } catch (e) {
-      if (e instanceof SyntaxError) {
+      if (e instanceof DotSyntaxError) {
         console.log(e.location);
       }
       throw e;

--- a/src/ast/dot-shim/parser/dot.peggy
+++ b/src/ast/dot-shim/parser/dot.peggy
@@ -16,7 +16,7 @@
     return str;
   }
 
-  const edgeops: { operator: '--' | '->', location: IFileRange }[] = [];
+  const edgeops: { operator: '--' | '->', location: FileRange }[] = [];
 
   const b = new Builder({
     locationFunction: location,

--- a/src/ast/dot-shim/parser/parse.ts
+++ b/src/ast/dot-shim/parser/parse.ts
@@ -9,7 +9,7 @@ import type {
   SubgraphASTNode,
   ASTNode,
 } from '../../types.js';
-import { parse as _parse, SyntaxError as _SyntaxError } from './_parse.js';
+import { parse as _parse, DotSyntaxError as _DotSyntaxError } from './_parse.js';
 /**
  * @group Convert DOT to AST
  */
@@ -49,4 +49,4 @@ export function parse(input: string, options?: ParseOptions<Rule>): ASTNode | Cl
 /**
  * @group Convert DOT to AST
  */
-export const SyntaxError = _SyntaxError;
+export const DotSyntaxError = _DotSyntaxError;

--- a/src/ast/dot-shim/parser/peggy.options.json
+++ b/src/ast/dot-shim/parser/peggy.options.json
@@ -1,6 +1,7 @@
 {
   "allowedStartRules": ["Dot", "Graph", "Subgraph", "Node", "Edge", "AttributeList", "Attribute", "ClusterStatements"],
   "tspegjs": {
-    "customHeader": "/* eslint-disable */\nimport { Builder } from '../../builder/index.js';"
+    "customHeader": "/* eslint-disable */\nimport { Builder } from '../../builder/index.js';",
+    "errorName": "DotSyntaxError"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3467,10 +3467,10 @@ ts-jest@^29.0.5:
     semver "7.x"
     yargs-parser "^21.0.1"
 
-ts-pegjs@^2.1.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/ts-pegjs/-/ts-pegjs-2.2.1.tgz#57ed509508d6964d66b878f6a22ef37e3c43efad"
-  integrity sha512-wZVrGqGNjmcDHQ8RyrzAh7ixjqhtX0cCgRcnl5BjsZjVUsEjzcfdRj7MUGkYMPJcF1ULI60jW7CPPbhYwTA8bQ==
+ts-pegjs@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ts-pegjs/-/ts-pegjs-3.0.0.tgz#3883d0772c56a059a55c95e09a3e5f4e076acddc"
+  integrity sha512-0yTchsO04jfYl/85sibupLSb7PfXs890jN9WqXoI6+WrFilam3+44ZdjBwIKPc9n2jdSbcxfdMvXNNwNEHSLCg==
 
 tsconfig-paths@^3.14.1:
   version "3.14.1"


### PR DESCRIPTION
<!-- Thank you for your contribution to ts-graphviz! Please replace {Please write here} with your description -->

### What was a problem

See https://github.com/metadevpro/ts-pegjs/pull/86

### How this PR fixes the problem

Rename to `DotSyntaxError`.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)
