### PR TITLE
add Blank type for reset attribute

### DIFF
--- a/src/common/attribute/attribute.ts
+++ b/src/common/attribute/attribute.ts
@@ -3,6 +3,7 @@ import type {
   AddDouble,
   AddPoint,
   ArrowType,
+  Blank,
   ClusterMode,
   Color,
   ColorList,
@@ -73,7 +74,7 @@ interface KeyValueMapping {
   fontpath: string;
   fontsize: Double;
   forcelabels: boolean;
-  gradientangle: Int;
+  gradientangle: Blank | Int;
   group: string;
   head_lp: Point;
   headclip: boolean;
@@ -83,7 +84,7 @@ interface KeyValueMapping {
   headtarget: EscString;
   headtooltip: EscString;
   headURL: EscString;
-  height: Double;
+  height: Blank | Double;
   href: EscString;
   id: EscString;
   image: string;
@@ -181,8 +182,8 @@ interface KeyValueMapping {
   smoothing: SmoothType;
   sortv: Int;
   splines: boolean | string;
-  start: StartType;
-  style: Style;
+  start: Blank | StartType;
+  style: Blank | Style;
   stylesheet: string;
   tail_lp: string;
   tailclip: Point;
@@ -197,14 +198,14 @@ interface KeyValueMapping {
   truecolor: boolean;
   URL: EscString;
   vertices: PointList;
-  viewport: ViewPort;
+  viewport: Blank | ViewPort;
   voro_margin: Double;
   weight: Int | Double;
   width: Double;
   xdotversion: string;
   xlabel: LblString;
   xlp: Point;
-  z: Double;
+  z: Blank | Double;
 }
 
 /**

--- a/src/common/type/types.ts
+++ b/src/common/type/types.ts
@@ -5,6 +5,12 @@
 export type Compass = 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'nw' | 'c' | '_';
 
 /**
+ * A value specifying an empty string for resetting some values.
+ * @group Attribute Types
+ */
+export type Blank = '';
+
+/**
  * A double with an optional prefix `'+'`.
  *
  * @see {@link https://graphviz.gitlab.io/docs/attr-types/addDouble/ addDouble}


### PR DESCRIPTION
<!-- Thank you for your contribution to ts-graphviz! Please replace {Please write here} with your description -->

### What was a problem

Specifying an empty string for resetting attribute values was not possible due to TypeScript type restrictions.
 
```dot
a -> b [style=""]
```

### How this PR fixes the problem

Introduced the Blank type, allowing the reset to be specified.
The default value of `""` can be set to blank.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)
