### PR TITLE
chaos: remove code doc from JS code, not from d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "build:peggy": "peggy --plugin ts-pegjs --extra-options-file src/ast/dot-shim/parser/peggy.options.json -o src/ast/dot-shim/parser/_parse.ts src/ast/dot-shim/parser/dot.peggy",
     "prebuild": "yarn build:peggy",
     "build:deno": "mkdir -p lib/adapter/deno && cp -r src/adapter/deno/* lib/adapter/deno && sed -i \"s/index.ts/index.js/g\" lib/adapter/deno/mod.js && sed -i \"s/index.ts/index.d.ts/g\" lib/adapter/deno/mod.d.ts",
-    "build:node": "tsc -p tsconfig.build.json && rollup -c",
+    "build:node": "tsc -p tsconfig.build.json --declaration && tsc -p tsconfig.build.json --removeComments && rollup -c",
     "build": "yarn build:node && yarn build:deno",
     "postbuild": "prettier --write ./lib/**/*.{js,cjs,d.ts}",
     "pretest": "yarn build:peggy",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
     "esModuleInterop": true,
     "moduleResolution": "Node16",
     "skipLibCheck": true,
-    "declaration": true,
     "forceConsistentCasingInFileNames": true,
     "paths": {
       "#test/*": ["./test/*/index.js"],


### PR DESCRIPTION
<!-- Thank you for your contribution to ts-graphviz! Please replace {Please write here} with your description -->

### What was a problem

Code documentation is included in both the type definition file and JavaScript source code in the library output.

This leads to an increase in bundle size and degrades distributability.

### How this PR fixes the problem

Modify the build process so that only the code documentation is included in the type definition and only the source code in the JavaScript.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)
