### PR TITLE
fix: Add jest setting for resolve test failed after e2e test

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -11,5 +11,6 @@
     "^\\#test\\/(.*)$": "<rootDir>/test/$1",
     "^(\\.{1,2}/.*)\\.js$": "$1"
   },
-  "snapshotSerializers": ["jest-snapshot-serializer-raw"]
+  "snapshotSerializers": ["jest-snapshot-serializer-raw"],
+  "modulePathIgnorePatterns": ["<rootDir>/e2e"]
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to ts-graphviz! Please replace {Please write here} with your description -->

### What was a problem

The test was failing after the E2E test was conducted.

This was due to a problem with the jest package resolution g not working properly, as the E2E test emulated the installation of ts-graphviz under the e2e directory.

### How this PR fixes the problem

Added jest setting to ignore under e2e directory.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)
