### PR TITLE
fix: improve crealeElement function

### DIFF
--- a/src/ast/builder/builder.ts
+++ b/src/ast/builder/builder.ts
@@ -30,11 +30,11 @@ export class Builder implements ASTBuilder {
    * @returns An {@link ASTNode}
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public createElement<T extends ASTNode>(type: T['type'], props: any, children: ASTChildNode<T>[]): T {
+  public createElement<T extends ASTNode>(type: T['type'], props: any, children: ASTChildNode<T>[] = []): T {
     return {
+      location: this.getLocation(),
       ...props,
       type,
-      location: this.getLocation(),
       children,
     };
   }

--- a/src/ast/builder/create-element.test.ts
+++ b/src/ast/builder/create-element.test.ts
@@ -7,123 +7,67 @@ describe('createElement', () => {
   });
 
   test('Graph', () => {
-    const ast = createElement(
-      'Graph',
-      {
-        strict: false,
-        directed: true,
-      },
-      [],
-    );
+    const ast = createElement('Graph', {
+      strict: false,
+      directed: true,
+    });
     expect(ast).toMatchSnapshot();
   });
 
   test('Node', () => {
-    const ast = createElement(
-      'Node',
-      {
-        id: createElement(
-          'Literal',
-          {
-            value: 'node_id',
-            quoted: false,
-          },
-          [],
-        ),
-      },
-      [],
-    );
+    const ast = createElement('Node', {
+      id: createElement('Literal', {
+        value: 'node_id',
+        quoted: false,
+      }),
+    });
     expect(ast).toMatchSnapshot();
   });
 
   test('Edge', () => {
-    const ast = createElement(
-      'Edge',
-      {
-        targets: [
-          createElement(
-            'NodeRef',
-            {
-              id: createElement(
-                'Literal',
-                {
-                  value: 'a',
-                  quoted: true,
-                },
-                [],
-              ),
-            },
-            [],
-          ),
-          createElement(
-            'NodeRef',
-            {
-              id: createElement(
-                'Literal',
-                {
-                  value: 'b',
-                  quoted: true,
-                },
-                [],
-              ),
-            },
-            [],
-          ),
-        ],
-      },
-      [],
-    );
+    const ast = createElement('Edge', {
+      targets: [
+        createElement('NodeRef', {
+          id: createElement('Literal', {
+            value: 'a',
+            quoted: true,
+          }),
+        }),
+        createElement('NodeRef', {
+          id: createElement('Literal', {
+            value: 'b',
+            quoted: true,
+          }),
+        }),
+      ],
+    });
     expect(ast).toMatchSnapshot();
   });
 
   test('NodeRef', () => {
-    const ast = createElement(
-      'NodeRef',
-      {
-        id: createElement(
-          'Literal',
-          {
-            value: 'b',
-            quoted: true,
-          },
-          [],
-        ),
-      },
-      [],
-    );
+    const ast = createElement('NodeRef', {
+      id: createElement('Literal', {
+        value: 'b',
+        quoted: true,
+      }),
+    });
     expect(ast).toMatchSnapshot();
   });
 
   test('NodeRefGroup', () => {
     const ast = createElement('NodeRefGroup', {}, [
-      createElement(
-        'NodeRef',
-        {
-          id: createElement(
-            'Literal',
-            {
-              value: 'a',
-              quoted: true,
-            },
-            [],
-          ),
-        },
-        [],
-      ),
-      createElement(
-        'NodeRef',
-        {
-          id: createElement(
-            'Literal',
-            {
-              value: 'b',
-              quoted: true,
-            },
-            [],
-          ),
-        },
-        [],
-      ),
+      createElement('NodeRef', {
+        id: createElement('Literal', {
+          value: 'a',
+          quoted: true,
+        }),
+      }),
+      createElement('NodeRef', {
+        id: createElement('Literal', {
+          value: 'b',
+          quoted: true,
+        }),
+      }),
     ]);
     expect(ast).toMatchSnapshot();
   });
@@ -134,52 +78,32 @@ describe('createElement', () => {
   });
 
   test('Literal', () => {
-    const ast = createElement(
-      'Literal',
-      {
-        value: 'literal value',
-        quoted: true,
-      },
-      [],
-    );
+    const ast = createElement('Literal', {
+      value: 'literal value',
+      quoted: true,
+    });
     expect(ast).toMatchSnapshot();
   });
 
   test('Coment', () => {
-    const ast = createElement(
-      'Comment',
-      {
-        kind: 'Macro',
-        value: 'This is comment',
-      },
-      [],
-    );
+    const ast = createElement('Comment', {
+      kind: 'Macro',
+      value: 'This is comment',
+    });
     expect(ast).toMatchSnapshot();
   });
 
   test('Attribute', () => {
-    const ast = createElement(
-      'Attribute',
-      {
-        key: createElement(
-          'Literal',
-          {
-            value: 'color',
-            quoted: false,
-          },
-          [],
-        ),
-        value: createElement(
-          'Literal',
-          {
-            value: 'red',
-            quoted: false,
-          },
-          [],
-        ),
-      },
-      [],
-    );
+    const ast = createElement('Attribute', {
+      key: createElement('Literal', {
+        value: 'color',
+        quoted: false,
+      }),
+      value: createElement('Literal', {
+        value: 'red',
+        quoted: false,
+      }),
+    });
     expect(ast).toMatchSnapshot();
   });
 });

--- a/src/ast/builder/types.ts
+++ b/src/ast/builder/types.ts
@@ -1,3 +1,4 @@
+import { AttributeKey } from '../../common/index.js';
 import type {
   ASTChildNode,
   AttributeASTNode,
@@ -56,7 +57,7 @@ export interface CreateElement {
   <T extends string>(
     type: 'Literal',
     props: LiteralASTPropaties<T>,
-    children: ASTChildNode<LiteralASTNode>[],
+    children?: ASTChildNode<LiteralASTNode>[],
   ): LiteralASTNode<T>;
   /**
    * Creates a LiteralASTNode with the given type, properties, and children.
@@ -66,7 +67,7 @@ export interface CreateElement {
    * @param children The children of the AST node.
    * @returns A {@link LiteralASTNode} with the given type, properties, and children.
    */
-  (type: 'Literal', props: LiteralASTPropaties, children: ASTChildNode<LiteralASTNode>[]): LiteralASTNode;
+  (type: 'Literal', props: LiteralASTPropaties, children?: ASTChildNode<LiteralASTNode>[]): LiteralASTNode;
 
   /**
    * Creates a {@link DotASTNode} with the given type, properties, and children.
@@ -76,7 +77,7 @@ export interface CreateElement {
    * @param children The children of the AST node.
    * @returns A {@link DotASTNode} with the given type, properties, and children.
    */
-  (type: 'Dot', props: DotASTPropaties, children: ASTChildNode<DotASTNode>[]): DotASTNode;
+  (type: 'Dot', props: DotASTPropaties, children?: ASTChildNode<DotASTNode>[]): DotASTNode;
 
   /**
    * Creates a {@link GraphASTNode} with the given type, properties, and children.
@@ -86,7 +87,7 @@ export interface CreateElement {
    * @param children The children of the AST node.
    * @returns A {GraphASTNode} with the given type, properties, and children.
    */
-  (type: 'Graph', props: GraphASTPropaties, children: ASTChildNode<GraphASTNode>[]): GraphASTNode;
+  (type: 'Graph', props: GraphASTPropaties, children?: ASTChildNode<GraphASTNode>[]): GraphASTNode;
 
   /**
    * Creates an {@link AttributeASTNode} with the given type, properties, and children.
@@ -96,7 +97,12 @@ export interface CreateElement {
    * @param children The children of the AST node.
    * @returns An {@link AttributeASTNode} with the given type, properties, and children.
    */
-  (type: 'Attribute', props: AttributeASTPropaties, children: ASTChildNode<AttributeASTNode>[]): AttributeASTNode;
+  <T extends AttributeKey>(
+    type: 'Attribute',
+    props: AttributeASTPropaties<T>,
+    children?: ASTChildNode<AttributeASTNode>[],
+  ): AttributeASTNode<T>;
+  (type: 'Attribute', props: AttributeASTPropaties, children?: ASTChildNode<AttributeASTNode>[]): AttributeASTNode;
 
   /**
    * Creates a {@link CommentASTNode} with the given type, properties, and children.
@@ -106,7 +112,7 @@ export interface CreateElement {
    * @param children The children of the AST node.
    * @returns A {@link CommentASTNode} with the given type, properties, and children.
    */
-  (type: 'Comment', props: CommentASTPropaties, children: ASTChildNode<CommentASTNode>[]): CommentASTNode;
+  (type: 'Comment', props: CommentASTPropaties, children?: ASTChildNode<CommentASTNode>[]): CommentASTNode;
 
   /**
    * Creates an {@link AttributeListASTNode} with the given type, properties, and children.
@@ -119,7 +125,7 @@ export interface CreateElement {
   (
     type: 'AttributeList',
     props: AttributeListASTPropaties,
-    children: ASTChildNode<AttributeListASTNode>[],
+    children?: ASTChildNode<AttributeListASTNode>[],
   ): AttributeListASTNode;
 
   /**
@@ -130,7 +136,7 @@ export interface CreateElement {
    * @param children The children of the AST node.
    * @returns A {@link NodeRefASTNode} with the given type, properties, and children.
    */
-  (type: 'NodeRef', props: NodeRefASTPropaties, children: ASTChildNode<NodeRefASTNode>[]): NodeRefASTNode;
+  (type: 'NodeRef', props: NodeRefASTPropaties, children?: ASTChildNode<NodeRefASTNode>[]): NodeRefASTNode;
 
   /**
    * Creates a {@link NodeRefGroupASTNode} with the given type, properties, and children.
@@ -143,7 +149,7 @@ export interface CreateElement {
   (
     type: 'NodeRefGroup',
     props: NodeRefGroupASTPropaties,
-    children: ASTChildNode<NodeRefGroupASTNode>[],
+    children?: ASTChildNode<NodeRefGroupASTNode>[],
   ): NodeRefGroupASTNode;
 
   /**
@@ -154,7 +160,7 @@ export interface CreateElement {
    * @param children The children of the AST node.
    * @returns An {@link EdgeASTNode} with the given type, properties, and children.
    */
-  (type: 'Edge', props: EdgeASTPropaties, children: ASTChildNode<EdgeASTNode>[]): EdgeASTNode;
+  (type: 'Edge', props: EdgeASTPropaties, children?: ASTChildNode<EdgeASTNode>[]): EdgeASTNode;
 
   /**
    * Creates a {@link NodeASTNode} with the given type, properties, and children.
@@ -164,7 +170,7 @@ export interface CreateElement {
    * @param children The children of the AST node.
    * @returns A {@link NodeASTNode} with the given type, properties, and children.
    */
-  (type: 'Node', props: NodeASTPropaties, children: ASTChildNode<NodeASTNode>[]): NodeASTNode;
+  (type: 'Node', props: NodeASTPropaties, children?: ASTChildNode<NodeASTNode>[]): NodeASTNode;
 
   /**
    * Creates a {@link SubgraphASTNode} with the given type, properties, and children.
@@ -174,7 +180,7 @@ export interface CreateElement {
    * @param children The children of the AST node.
    * @returns A {@link SubgraphASTNode} with the given type, properties, and children.
    */
-  (type: 'Subgraph', props: SubgraphASTPropaties, children: ASTChildNode<SubgraphASTNode>[]): SubgraphASTNode;
+  (type: 'Subgraph', props: SubgraphASTPropaties, children?: ASTChildNode<SubgraphASTNode>[]): SubgraphASTNode;
 }
 
 /**

--- a/src/common/attribute/keys.ts
+++ b/src/common/attribute/keys.ts
@@ -262,6 +262,7 @@ export namespace SubgraphAttributeKey {
   export type values = keyof $values;
   export interface $values extends $keywords<'rank'> {}
 }
+
 /**
  * Attribute types available for cluster subgraph.
  * @group Attribute

--- a/src/common/type/types.ts
+++ b/src/common/type/types.ts
@@ -76,7 +76,7 @@ export type Shape = string;
  * @see {@link https://graphviz.gitlab.io/docs/attr-types/smoothType/ smoothType}
  * @group Attribute Types
  */
-export type SmoothType = SmoothType.$values;
+export type SmoothType = SmoothType.values;
 /** @hidden */
 export namespace SmoothType {
   export type values = keyof $values;


### PR DESCRIPTION
- Make children non-mandatory in createElement function so that ASTs can be generated with a smaller amount of code.
- Modified to give priority to the location of props passed in the createElement function.
- The type parameter is now accepted when creating an AttributeASTNode with the createElement function.
- Fixed an issue with incorrect SmoothType type