### PR TITLE
feat: Support exclude types

### DIFF
--- a/src/adapter/types/index.ts
+++ b/src/adapter/types/index.ts
@@ -9,16 +9,18 @@ import { $keywords } from '../../utils/index.js';
 
 export type Format = Format.values;
 export namespace Format {
-  export type values = keyof $values;
+  export type values = Exclude<keyof $values, keyof $exclude>;
   export interface $values
     extends $keywords<'png' | 'svg' | 'json' | 'jpg' | 'pdf' | 'xdot' | 'dot' | 'plain' | 'dot_json'> {}
+  export interface $exclude {}
 }
 
 export type Layout = Layout.values;
 export namespace Layout {
-  export type values = keyof $values;
+  export type values = Exclude<keyof $values, keyof $exclude>;
   export interface $values
     extends $keywords<'dot' | 'neato' | 'fdp' | 'sfdp' | 'circo' | 'twopi' | 'nop' | 'nop2' | 'osage' | 'patchwork'> {}
+  export interface $exclude {}
 }
 
 /**

--- a/src/adapter/types/index.ts
+++ b/src/adapter/types/index.ts
@@ -5,22 +5,22 @@ import {
   NodeAttributesObject,
   SubgraphAttributesObject,
 } from '../../common/index.js';
-import { $keywords } from '../../utils/index.js';
+import { $keywords, $keywordsValidation } from '../../utils/index.js';
 
 export type Format = Format.values;
 export namespace Format {
-  export type values = Exclude<keyof $values, keyof $exclude>;
+  export type values = Exclude<keyof $values, keyof $exclude | symbol | number>;
   export interface $values
     extends $keywords<'png' | 'svg' | 'json' | 'jpg' | 'pdf' | 'xdot' | 'dot' | 'plain' | 'dot_json'> {}
-  export interface $exclude {}
+  export interface $exclude extends $keywordsValidation {}
 }
 
 export type Layout = Layout.values;
 export namespace Layout {
-  export type values = Exclude<keyof $values, keyof $exclude>;
+  export type values = Exclude<keyof $values, keyof $exclude | symbol | number>;
   export interface $values
     extends $keywords<'dot' | 'neato' | 'fdp' | 'sfdp' | 'circo' | 'twopi' | 'nop' | 'nop2' | 'osage' | 'patchwork'> {}
-  export interface $exclude {}
+  export interface $exclude extends $keywordsValidation {}
 }
 
 /**

--- a/src/common/attribute/attribute.ts
+++ b/src/common/attribute/attribute.ts
@@ -43,9 +43,9 @@ import type {
  */
 export type Attribute<T extends AttributeKey> = Attribute.types[T];
 export namespace Attribute {
-  export type keys = Omit<$keys, keyof $exclude>;
+  export type keys = Omit<$keys, keyof $exclude | symbol | number>;
 
-  export type types = Omit<$types, keyof $exclude>;
+  export type types = Omit<$types, keyof $exclude | symbol | number>;
 
   /** @hidden */
   export interface $keys extends $keywords<AttributeKey> {}

--- a/src/common/attribute/attribute.ts
+++ b/src/common/attribute/attribute.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
-import { $keywords } from '../../utils/index.js';
+import { $keywords, $keywordsValidation } from '../../utils/index.js';
 import type { AttributeKey } from './keys.js';
 import type {
   AddDouble,
@@ -50,7 +50,7 @@ export namespace Attribute {
   /** @hidden */
   export interface $keys extends $keywords<AttributeKey> {}
 
-  export interface $exclude {}
+  export interface $exclude extends $keywordsValidation {}
 
   /**
    * @group Attribute

--- a/src/common/attribute/attribute.ts
+++ b/src/common/attribute/attribute.ts
@@ -41,12 +41,17 @@ import type {
  * @param T The {@link AttributeKey} to be mapped to a value.
  * @group Attribute
  */
-export type Attribute<T extends AttributeKey> = Attribute.$types[T];
+export type Attribute<T extends AttributeKey> = Attribute.types[T];
 export namespace Attribute {
-  export type keys = $keys;
+  export type keys = Omit<$keys, keyof $exclude>;
+
+  export type types = Omit<$types, keyof $exclude>;
 
   /** @hidden */
   export interface $keys extends $keywords<AttributeKey> {}
+
+  export interface $exclude {}
+
   /**
    * @group Attribute
    */

--- a/src/common/attribute/keys.ts
+++ b/src/common/attribute/keys.ts
@@ -1,13 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
-import { $keywords } from '../../utils/index.js';
-
-interface KeyValidation
-  extends $keywords<
-    // Note
-    // Although the DOT language specification allows the use of white space characters in IDs, for example by quoting,
-    // this is eliminated as a use case for the library.
-    `${string} ${string}` | `${string}\n${string}` | `${string}\t${string}`
-  > {}
+import { $keywords, $keywordsValidation } from '../../utils/index.js';
 
 /**
  * Attribute types available for edges.
@@ -87,7 +79,7 @@ export namespace EdgeAttributeKey {
       | 'class'
     > {}
 
-  export interface $exclude extends KeyValidation {}
+  export interface $exclude extends $keywordsValidation {}
 }
 
 /**
@@ -150,7 +142,7 @@ export namespace NodeAttributeKey {
       | 'z'
       | 'class'
     > {}
-  export interface $exclude extends KeyValidation {}
+  export interface $exclude extends $keywordsValidation {}
 }
 /**
  * Attribute types available for graph.
@@ -262,7 +254,7 @@ export namespace GraphAttributeKey {
       | 'xdotversion'
       | 'class'
     > {}
-  export interface $exclude extends KeyValidation {}
+  export interface $exclude extends $keywordsValidation {}
 }
 /**
  * Attribute types available for subgraph.
@@ -273,7 +265,7 @@ export type SubgraphAttributeKey = SubgraphAttributeKey.values;
 export namespace SubgraphAttributeKey {
   export type values = Exclude<keyof $values, keyof $exclude | symbol | number>;
   export interface $values extends $keywords<'rank'> {}
-  export interface $exclude extends KeyValidation {}
+  export interface $exclude extends $keywordsValidation {}
 }
 
 /**
@@ -317,7 +309,7 @@ export namespace ClusterSubgraphAttributeKey {
       | 'tooltip'
       | 'class'
     > {}
-  export interface $exclude extends KeyValidation {}
+  export interface $exclude extends $keywordsValidation {}
 }
 /**
  * Attribute types.

--- a/src/common/attribute/keys.ts
+++ b/src/common/attribute/keys.ts
@@ -1,6 +1,14 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 import { $keywords } from '../../utils/index.js';
 
+interface KeyValidation
+  extends $keywords<
+    // Note
+    // Although the DOT language specification allows the use of white space characters in IDs, for example by quoting,
+    // this is eliminated as a use case for the library.
+    `${string} ${string}` | `${string}\n${string}` | `${string}\t${string}`
+  > {}
+
 /**
  * Attribute types available for edges.
  * @group Attribute
@@ -8,7 +16,7 @@ import { $keywords } from '../../utils/index.js';
 export type EdgeAttributeKey = EdgeAttributeKey.values;
 /** @hidden */
 export namespace EdgeAttributeKey {
-  export type values = Exclude<keyof $values, keyof $exclude>;
+  export type values = Exclude<keyof $values, keyof $exclude | symbol | number>;
   export interface $values
     extends $keywords<
       | 'URL'
@@ -78,7 +86,8 @@ export namespace EdgeAttributeKey {
       | 'xlp'
       | 'class'
     > {}
-  export interface $exclude {}
+
+  export interface $exclude extends KeyValidation {}
 }
 
 /**
@@ -88,7 +97,7 @@ export namespace EdgeAttributeKey {
 export type NodeAttributeKey = NodeAttributeKey.values;
 /** @hidden */
 export namespace NodeAttributeKey {
-  export type values = Exclude<keyof $values, keyof $exclude>;
+  export type values = Exclude<keyof $values, keyof $exclude | symbol | number>;
   export interface $values
     extends $keywords<
       | 'URL'
@@ -141,7 +150,7 @@ export namespace NodeAttributeKey {
       | 'z'
       | 'class'
     > {}
-  export interface $exclude {}
+  export interface $exclude extends KeyValidation {}
 }
 /**
  * Attribute types available for graph.
@@ -150,7 +159,7 @@ export namespace NodeAttributeKey {
 export type GraphAttributeKey = GraphAttributeKey.values;
 /** @hidden */
 export namespace GraphAttributeKey {
-  export type values = Exclude<keyof $values, keyof $exclude>;
+  export type values = Exclude<keyof $values, keyof $exclude | symbol | number>;
   export interface $values
     extends $keywords<
       | 'Damping'
@@ -253,7 +262,7 @@ export namespace GraphAttributeKey {
       | 'xdotversion'
       | 'class'
     > {}
-  export interface $exclude {}
+  export interface $exclude extends KeyValidation {}
 }
 /**
  * Attribute types available for subgraph.
@@ -262,9 +271,9 @@ export namespace GraphAttributeKey {
 export type SubgraphAttributeKey = SubgraphAttributeKey.values;
 /** @hidden */
 export namespace SubgraphAttributeKey {
-  export type values = Exclude<keyof $values, keyof $exclude>;
+  export type values = Exclude<keyof $values, keyof $exclude | symbol | number>;
   export interface $values extends $keywords<'rank'> {}
-  export interface $exclude {}
+  export interface $exclude extends KeyValidation {}
 }
 
 /**
@@ -274,7 +283,7 @@ export namespace SubgraphAttributeKey {
 export type ClusterSubgraphAttributeKey = ClusterSubgraphAttributeKey.values;
 /** @hidden */
 export namespace ClusterSubgraphAttributeKey {
-  export type values = Exclude<keyof $values, keyof $exclude>;
+  export type values = Exclude<keyof $values, keyof $exclude | symbol | number>;
   export interface $values
     extends $keywords<
       | 'K'
@@ -308,7 +317,7 @@ export namespace ClusterSubgraphAttributeKey {
       | 'tooltip'
       | 'class'
     > {}
-  export interface $exclude {}
+  export interface $exclude extends KeyValidation {}
 }
 /**
  * Attribute types.

--- a/src/common/attribute/keys.ts
+++ b/src/common/attribute/keys.ts
@@ -8,7 +8,7 @@ import { $keywords } from '../../utils/index.js';
 export type EdgeAttributeKey = EdgeAttributeKey.values;
 /** @hidden */
 export namespace EdgeAttributeKey {
-  export type values = keyof $values;
+  export type values = Exclude<keyof $values, keyof $exclude>;
   export interface $values
     extends $keywords<
       | 'URL'
@@ -78,6 +78,7 @@ export namespace EdgeAttributeKey {
       | 'xlp'
       | 'class'
     > {}
+  export interface $exclude {}
 }
 
 /**
@@ -87,7 +88,7 @@ export namespace EdgeAttributeKey {
 export type NodeAttributeKey = NodeAttributeKey.values;
 /** @hidden */
 export namespace NodeAttributeKey {
-  export type values = keyof $values;
+  export type values = Exclude<keyof $values, keyof $exclude>;
   export interface $values
     extends $keywords<
       | 'URL'
@@ -140,6 +141,7 @@ export namespace NodeAttributeKey {
       | 'z'
       | 'class'
     > {}
+  export interface $exclude {}
 }
 /**
  * Attribute types available for graph.
@@ -148,7 +150,7 @@ export namespace NodeAttributeKey {
 export type GraphAttributeKey = GraphAttributeKey.values;
 /** @hidden */
 export namespace GraphAttributeKey {
-  export type values = keyof $values;
+  export type values = Exclude<keyof $values, keyof $exclude>;
   export interface $values
     extends $keywords<
       | 'Damping'
@@ -251,6 +253,7 @@ export namespace GraphAttributeKey {
       | 'xdotversion'
       | 'class'
     > {}
+  export interface $exclude {}
 }
 /**
  * Attribute types available for subgraph.
@@ -259,8 +262,9 @@ export namespace GraphAttributeKey {
 export type SubgraphAttributeKey = SubgraphAttributeKey.values;
 /** @hidden */
 export namespace SubgraphAttributeKey {
-  export type values = keyof $values;
+  export type values = Exclude<keyof $values, keyof $exclude>;
   export interface $values extends $keywords<'rank'> {}
+  export interface $exclude {}
 }
 
 /**
@@ -270,7 +274,7 @@ export namespace SubgraphAttributeKey {
 export type ClusterSubgraphAttributeKey = ClusterSubgraphAttributeKey.values;
 /** @hidden */
 export namespace ClusterSubgraphAttributeKey {
-  export type values = keyof $values;
+  export type values = Exclude<keyof $values, keyof $exclude>;
   export interface $values
     extends $keywords<
       | 'K'
@@ -304,6 +308,7 @@ export namespace ClusterSubgraphAttributeKey {
       | 'tooltip'
       | 'class'
     > {}
+  export interface $exclude {}
 }
 /**
  * Attribute types.

--- a/src/common/type/types.ts
+++ b/src/common/type/types.ts
@@ -8,8 +8,9 @@ import { $keywords } from '../../utils/index.js';
 export type Compass = Compass.values;
 /** @hidden */
 export namespace Compass {
-  export type values = keyof $values;
+  export type values = Exclude<keyof $values, keyof $exclude>;
   export interface $values extends $keywords<'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'nw' | 'c' | '_'> {}
+  export interface $exclude {}
 }
 
 /**
@@ -79,9 +80,11 @@ export type Shape = string;
 export type SmoothType = SmoothType.values;
 /** @hidden */
 export namespace SmoothType {
-  export type values = keyof $values;
+  export type values = Exclude<keyof $values, keyof $exclude>;
+
   export interface $values
     extends $keywords<'none' | 'avg_dist' | 'graph_dist' | 'power_dist' | 'rng' | 'spring' | 'triangle'> {}
+  export interface $exclude {}
 }
 /**
  * @see {@link https://graphviz.gitlab.io/docs/attr-types/splineType/ splineType}
@@ -104,9 +107,10 @@ export namespace SplineType {
 export type StartType = `${StartType.style}${StartType.seed}`;
 /** @hidden */
 export namespace StartType {
-  export type style = keyof $style;
+  export type style = Exclude<keyof $style, keyof $exclude>;
   export interface $style extends $keywords<'regular' | 'self' | 'random'> {}
   export type seed = number;
+  export interface $exclude {}
 }
 
 /**
@@ -120,7 +124,7 @@ export type Style =
   | `${Style.styleItem},${Style.styleItem},${Style.styleItem},${Style.styleItem}`;
 /** @hidden */
 export namespace Style {
-  export type styleItem = keyof $styleItem;
+  export type styleItem = Exclude<keyof $styleItem, keyof $exclude>;
   export interface $styleItem
     extends $keywords<
       | 'dashed'
@@ -139,6 +143,7 @@ export namespace Style {
       | 'rounded'
       | 'radial'
     > {}
+  export interface $exclude {}
 }
 
 /**
@@ -254,8 +259,10 @@ export type PointList =
 export type OutputMode = OutputMode.values;
 /** @hidden */
 export namespace OutputMode {
-  export type values = keyof $values;
+  export type values = Exclude<keyof $values, keyof $exclude>;
+
   export interface $values extends $keywords<'breadthfirst' | 'nodesfirst' | 'edgesfirst'> {}
+  export interface $exclude {}
 }
 /**
  * @see {@link https://graphviz.org/docs/attr-types/packMode/ packMode}
@@ -264,8 +271,10 @@ export namespace OutputMode {
 export type PackMode = keyof PickMode.$values | `array${string}`;
 /** @hidden */
 export namespace PickMode {
-  export type values = keyof $values;
+  export type values = Exclude<keyof $values, keyof $exclude>;
+
   export interface $values extends $keywords<'node' | 'clust' | 'graph'> {}
+  export interface $exclude {}
 }
 /**
  * Using `"fast"` gives about a 2-4 times overall speedup compared with `"normal"`,
@@ -277,8 +286,10 @@ export namespace PickMode {
 export type QuadType = QuadType.values;
 /** @hidden */
 export namespace QuadType {
-  export type values = keyof $values;
+  export type values = Exclude<keyof $values, keyof $exclude>;
+
   export interface $values extends $keywords<'normal' | 'fast' | 'none'> {}
+  export interface $exclude {}
 }
 
 /**
@@ -293,8 +304,10 @@ export namespace QuadType {
 export type Rankdir = Rankdir.values;
 /** @hidden */
 export namespace Rankdir {
-  export type values = keyof $values;
+  export type values = Exclude<keyof $values, keyof $exclude>;
+
   export interface $values extends $keywords<'TB' | 'LR' | 'BT' | 'RL'> {}
+  export interface $exclude {}
 }
 /**
  * @see {@link https://graphviz.gitlab.io/docs/attr-types/rankType/ rankType}
@@ -303,8 +316,10 @@ export namespace Rankdir {
 export type RankType = RankType.values;
 /** @hidden */
 export namespace RankType {
-  export type values = keyof $values;
+  export type values = Exclude<keyof $values, keyof $exclude>;
+
   export interface $values extends $keywords<'same' | 'min' | 'source' | 'max' | 'sink'> {}
+  export interface $exclude {}
 }
 /**
  * `"%f,%f,%f,%f"`
@@ -348,8 +363,10 @@ export namespace ArrowType {
  */
 export type ClusterMode = ClusterMode.values;
 export namespace ClusterMode {
-  export type values = keyof $values;
+  export type values = Exclude<keyof $values, keyof $exclude>;
+
   export interface $values extends $keywords<'local' | 'global' | 'none'> {}
+  export interface $exclude {}
 }
 /**
  * @see {@link https://graphviz.gitlab.io/docs/attr-types/color/ color}
@@ -377,7 +394,7 @@ export namespace Color {
    * Graphviz currently supports the X11 scheme, the SVG scheme, and the Brewer schemes, with X11 being the default.
    * @see {@link https://graphviz.org/doc/info/colors.html Color Names}
    */
-  export type ColorName = keyof $colors;
+  export type ColorName = Exclude<keyof $colors, keyof $exclude>;
   export interface $colors
     extends $keywords<
       | 'aliceblue'
@@ -1207,6 +1224,7 @@ export namespace Color {
       | 'yellow'
       | 'yellowgreen'
     > {}
+  export interface $exclude {}
 }
 
 /**
@@ -1230,8 +1248,10 @@ export type ColorList = string;
 export type DirType = DirType.values;
 /** @hidden */
 export namespace DirType {
-  export type values = keyof $values;
+  export type values = Exclude<keyof $values, keyof $exclude>;
+
   export interface $values extends $keywords<'forward' | 'back' | 'both' | 'none'> {}
+  export interface $exclude {}
 }
 
 /**

--- a/src/common/type/types.ts
+++ b/src/common/type/types.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
-import { $keywords } from '../../utils/index.js';
+import { $keywords, $keywordsValidation } from '../../utils/index.js';
 
 /**
  * Directive indicating which direction the Edge should point.
@@ -8,9 +8,9 @@ import { $keywords } from '../../utils/index.js';
 export type Compass = Compass.values;
 /** @hidden */
 export namespace Compass {
-  export type values = Exclude<keyof $values, keyof $exclude>;
+  export type values = Exclude<keyof $values, keyof $exclude | symbol | number>;
   export interface $values extends $keywords<'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'nw' | 'c' | '_'> {}
-  export interface $exclude {}
+  export interface $exclude extends $keywordsValidation {}
 }
 
 /**
@@ -80,11 +80,11 @@ export type Shape = string;
 export type SmoothType = SmoothType.values;
 /** @hidden */
 export namespace SmoothType {
-  export type values = Exclude<keyof $values, keyof $exclude>;
+  export type values = Exclude<keyof $values, keyof $exclude | symbol | number>;
 
   export interface $values
     extends $keywords<'none' | 'avg_dist' | 'graph_dist' | 'power_dist' | 'rng' | 'spring' | 'triangle'> {}
-  export interface $exclude {}
+  export interface $exclude extends $keywordsValidation {}
 }
 /**
  * @see {@link https://graphviz.gitlab.io/docs/attr-types/splineType/ splineType}
@@ -110,7 +110,7 @@ export namespace StartType {
   export type style = Exclude<keyof $style, keyof $exclude>;
   export interface $style extends $keywords<'regular' | 'self' | 'random'> {}
   export type seed = number;
-  export interface $exclude {}
+  export interface $exclude extends $keywordsValidation {}
 }
 
 /**
@@ -143,7 +143,7 @@ export namespace Style {
       | 'rounded'
       | 'radial'
     > {}
-  export interface $exclude {}
+  export interface $exclude extends $keywordsValidation {}
 }
 
 /**
@@ -259,10 +259,10 @@ export type PointList =
 export type OutputMode = OutputMode.values;
 /** @hidden */
 export namespace OutputMode {
-  export type values = Exclude<keyof $values, keyof $exclude>;
+  export type values = Exclude<keyof $values, keyof $exclude | symbol | number>;
 
   export interface $values extends $keywords<'breadthfirst' | 'nodesfirst' | 'edgesfirst'> {}
-  export interface $exclude {}
+  export interface $exclude extends $keywordsValidation {}
 }
 /**
  * @see {@link https://graphviz.org/docs/attr-types/packMode/ packMode}
@@ -271,10 +271,10 @@ export namespace OutputMode {
 export type PackMode = keyof PickMode.$values | `array${string}`;
 /** @hidden */
 export namespace PickMode {
-  export type values = Exclude<keyof $values, keyof $exclude>;
+  export type values = Exclude<keyof $values, keyof $exclude | symbol | number>;
 
   export interface $values extends $keywords<'node' | 'clust' | 'graph'> {}
-  export interface $exclude {}
+  export interface $exclude extends $keywordsValidation {}
 }
 /**
  * Using `"fast"` gives about a 2-4 times overall speedup compared with `"normal"`,
@@ -286,10 +286,10 @@ export namespace PickMode {
 export type QuadType = QuadType.values;
 /** @hidden */
 export namespace QuadType {
-  export type values = Exclude<keyof $values, keyof $exclude>;
+  export type values = Exclude<keyof $values, keyof $exclude | symbol | number>;
 
   export interface $values extends $keywords<'normal' | 'fast' | 'none'> {}
-  export interface $exclude {}
+  export interface $exclude extends $keywordsValidation {}
 }
 
 /**
@@ -301,14 +301,13 @@ export namespace QuadType {
  * @see {@link https://graphviz.gitlab.io/docs/attr-types/rankdir/ rankdir}
  * @group Attribute Types
  */
-export type Rankdir = Rankdir.values;
+export type Rankdir = `${Rankdir.TB}${Rankdir.RL}`;
 /** @hidden */
 export namespace Rankdir {
-  export type values = Exclude<keyof $values, keyof $exclude>;
-
-  export interface $values extends $keywords<'TB' | 'LR' | 'BT' | 'RL'> {}
-  export interface $exclude {}
+  export type TB = 'T' | 'B';
+  export type RL = 'R' | 'L';
 }
+
 /**
  * @see {@link https://graphviz.gitlab.io/docs/attr-types/rankType/ rankType}
  * @group Attribute Types
@@ -316,10 +315,10 @@ export namespace Rankdir {
 export type RankType = RankType.values;
 /** @hidden */
 export namespace RankType {
-  export type values = Exclude<keyof $values, keyof $exclude>;
+  export type values = Exclude<keyof $values, keyof $exclude | symbol | number>;
 
   export interface $values extends $keywords<'same' | 'min' | 'source' | 'max' | 'sink'> {}
-  export interface $exclude {}
+  export interface $exclude extends $keywordsValidation {}
 }
 /**
  * `"%f,%f,%f,%f"`
@@ -363,10 +362,10 @@ export namespace ArrowType {
  */
 export type ClusterMode = ClusterMode.values;
 export namespace ClusterMode {
-  export type values = Exclude<keyof $values, keyof $exclude>;
+  export type values = Exclude<keyof $values, keyof $exclude | symbol | number>;
 
   export interface $values extends $keywords<'local' | 'global' | 'none'> {}
-  export interface $exclude {}
+  export interface $exclude extends $keywordsValidation {}
 }
 /**
  * @see {@link https://graphviz.gitlab.io/docs/attr-types/color/ color}
@@ -1224,7 +1223,7 @@ export namespace Color {
       | 'yellow'
       | 'yellowgreen'
     > {}
-  export interface $exclude {}
+  export interface $exclude extends $keywordsValidation {}
 }
 
 /**
@@ -1248,10 +1247,10 @@ export type ColorList = string;
 export type DirType = DirType.values;
 /** @hidden */
 export namespace DirType {
-  export type values = Exclude<keyof $values, keyof $exclude>;
+  export type values = Exclude<keyof $values, keyof $exclude | symbol | number>;
 
   export interface $values extends $keywords<'forward' | 'back' | 'both' | 'none'> {}
-  export interface $exclude {}
+  export interface $exclude extends $keywordsValidation {}
 }
 
 /**

--- a/src/utils/type.ts
+++ b/src/utils/type.ts
@@ -1,6 +1,18 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
 /**
  * @hidden
  */
 export type $keywords<T extends string> = {
   [key in T]: key;
 };
+
+/**
+ * @hidden
+ */
+export interface $keywordsValidation
+  extends $keywords<
+    // Note
+    // Although the DOT language specification allows the use of white space characters in IDs, for example by quoting,
+    // this is eliminated as a use case for the library.
+    `${string} ${string}` | `${string}\n${string}` | `${string}\t${string}`
+  > {}


### PR DESCRIPTION
<!-- Thank you for your contribution to ts-graphviz! Please replace {Please write here} with your description -->

### What was a problem

String types could be freely added externally from outside the library, but could not be removed.

### How this PR fixes the problem

Type manipulation is now possible by users setting the type of `$exclude` as well as addition.
