### PR TITLE
fix: Add Type validation for get/set method

### DIFF
--- a/src/common/models.ts
+++ b/src/common/models.ts
@@ -169,9 +169,9 @@ export interface Attributes<T extends AttributeKey> {
    *
    * If the value corresponding to the key does not exist, undefined is returned.
    */
-  get(key: T): Attribute<T> | undefined;
+  get<K extends T>(key: K): Attribute<K> | undefined;
   /** Set a value, by specifying the key of the attributes in the DOT object. */
-  set(key: T, value: Attribute<T>): void;
+  set<K extends T>(key: K, value: Attribute<K>): void;
   /**
    * Apply keys and values that can be specified for DOT objects collectively.
    *

--- a/src/core/models/AttributesBase.ts
+++ b/src/core/models/AttributesBase.ts
@@ -24,11 +24,11 @@ export abstract class AttributesBase<T extends AttributeKey> extends DotObject i
     return this.#attrs.size;
   }
 
-  public get(key: T): Attribute<T> | undefined {
-    return this.#attrs.get(key);
+  public get<K extends T>(key: K): Attribute<K> | undefined {
+    return this.#attrs.get(key) as Attribute<K> | undefined;
   }
 
-  public set(key: T, value: Attribute<T>): void {
+  public set<K extends T>(key: K, value: Attribute<K>): void {
     if (value !== null && value !== undefined) {
       this.#attrs.set(key, value);
     }


### PR DESCRIPTION
### What was a problem

The type check of the value corresponding to the key of the set method was not performed.

```ts
graph.attributes.edge.set(attribute.color, 's'); // it should be error, but it is not error
```


### How this PR fixes the problem

This PR fixes the problem by adding a type check to the set method.

```ts
export interface Attributes<T extends AttributeKey> {
  ...
  get<K extends T>(key: K): Attribute<K> | undefined;
  set<K extends T>(key: K, value: Attribute<K>): void;
  ...
}
```

### Additional Context

close #900 