### PR TITLE
Add workflow for generating dependency updates changeset

### DIFF
--- a/.github/workflows/generate-changeset-on-dependabot.yaml
+++ b/.github/workflows/generate-changeset-on-dependabot.yaml
@@ -1,0 +1,39 @@
+name: Generate Dependency Updates Changeset
+
+on:
+  pull_request_target:
+    paths:
+      - '.github/workflows/*'
+      - 'pnpm-lock.yaml'
+      - 'package.json'
+jobs:
+  generate-changeset:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 2
+          ref: ${{ github.head_ref }}
+      - name: Generate Changeset
+        run: |
+          CHANGESET_NAME="dependency-update-pr${{ github.event.pull_request.number }}.md"
+          cat <<EOF > .changeset/$CHANGESET_NAME
+          ---
+          "ts-graphviz": "patch"
+          "@ts-graphviz/core": "patch"
+          "@ts-graphviz/common": "patch"
+          "@ts-graphviz/ast": "patch"
+          "@ts-graphviz/adapter": "patch"
+          ---
+
+          ${PR_TITLE}
+          EOF
+          git config user.name "GitHub Action"
+          git config user.email "action@github.com"
+          git add .changeset/$CHANGESET_NAME
+          git commit -m "Add changeset for $CHANGESET_NAME"
+          git push
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
This pull request adds a new workflow for generating dependency updates changeset. The workflow is triggered when a pull request is made by the dependabot[bot] user. It generates a changeset file with the necessary updates for the dependencies and commits it to the repository.