### PR TITLE
Migrate to pnpm and Update .gitignore

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -16,5 +16,12 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [
+    "@ts-graphviz-examples/deno",
+    "@ts-graphviz-examples/cjs",
+    "@ts-graphviz-examples/esm",
+    "@ts-graphviz-examples/typescript",
+    "@ts-graphviz-examples/webpack-build-node",
+    "@ts-graphviz-examples/webpack-build-web"
+  ]
 }


### PR DESCRIPTION
This pull request includes multiple commits that migrate the project to use pnpm as the package manager and update the .gitignore file. It also includes other changes related to code restyling, migration to Vite and Vitest, monorepolization, addition of examples and integration tests, Node.js version update, build configuration improvements, Deno setup for CI, Turbo build setup caching, GitHub Actions caching update, removal of unused Deno registry configurations, update of pnpm/action-setup to v3.0.0, addition of @types/node, update of dependencies and pipeline in turbo.json, refactor of Real World AST Snapshot tests, fix of import statement in real-world.test.ts, addition of lefthook, fix of escape function, removal of postinstall script, separation of packages, setup for Graphviz, addition of architecture documentation and version support policy, addition of codegen dependency to test:unit task, update of CI workflow to use Turbo and add integration tests, update of codegen inputs and outputs, update of build.yaml to include/exclude specific files and directories, update of artifact upload path in build workflow, addition of v2.0.0 Changeset, addition of PullRequest Snapshot Release workflow, addition of publishConfig to package.json files, update of package.json files with additional files, funding, and keywords, addition of Node.js engine requirement to package.json files, update of package descriptions and README, update of Makefile to use pnpm instead of yarn for svgo, update of tsconfig.json to remove empty "include" array, addition of .npmignore files and update of imports, removal of unnecessary files from package.json, addition of src folder to .npmignore files, update of Suponser badge link, fix of typedoc configuration, addition of CD workflow for automated release process, update of file extensions and dependencies in webpack build examples, and update of typedoc.json file.