### PR TITLE
Update devcontainer.json to remove deno.cache path

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,8 +26,7 @@
           "./examples/deno",
           "packages/ts-grahviz/src/adapter/deno.ts",
           "packages/ts-grahviz/lib/adapter/deno.js"
-        ],
-        "deno.cache": "./e2e/envs/deno/.deno"
+        ]
       }
     }
   },


### PR DESCRIPTION
This pull request updates the devcontainer.json file to remove the deno.cache path. This change ensures that the deno cache is not included in the repository, reducing the size and improving the cleanliness of the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed the Deno cache configuration setting to enhance compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->