### PR TITLE
Update workflow to generate changeset on Dependabot

### DIFF
--- a/.github/workflows/generate-changeset-on-dependabot.yaml
+++ b/.github/workflows/generate-changeset-on-dependabot.yaml
@@ -42,7 +42,13 @@ jobs:
           git config user.name "GitHub Action"
           git config user.email "action@github.com"
           git add .changeset/$CHANGESET_NAME
-          git commit -m "Add changeset for $CHANGESET_NAME"
-          git push
+          if ! git commit -m "Add changeset for $CHANGESET_NAME"; then
+            echo "Failed to commit changeset"
+            exit 1
+          fi
+          if ! git push; then
+            echo "Failed to push changeset"
+            exit 1
+          fi
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/generate-changeset-on-dependabot.yaml
+++ b/.github/workflows/generate-changeset-on-dependabot.yaml
@@ -3,7 +3,6 @@ name: Generate Dependency Updates Changeset
 on:
   pull_request_target:
     paths:
-      - '.github/workflows/*'
       - 'pnpm-lock.yaml'
       - 'package.json'
 permissions:


### PR DESCRIPTION
This pull request updates the workflow to generate a changeset on Dependabot. It removes the unnecessary path restriction for the workflow and includes changes to the `pnpm-lock.yaml` and `package.json` files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Chores**
	- Updated the workflow to refine the triggers for dependency updates, specifically excluding workflow files and including lock and package files for more accurate changeset generation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->