### PR TITLE
Fix doc artifact name

### DIFF
--- a/.changeset/happy-phones-warn.md
+++ b/.changeset/happy-phones-warn.md
@@ -1,0 +1,10 @@
+---
+"@ts-graphviz/adapter": patch
+"@ts-graphviz/ast": patch
+"@ts-graphviz/common": patch
+"@ts-graphviz/core": patch
+"@ts-graphviz/react": patch
+"ts-graphviz": patch
+---
+
+Fix documentation build failed

--- a/.github/workflows/.build.yaml
+++ b/.github/workflows/.build.yaml
@@ -42,3 +42,4 @@ jobs:
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           path: doc
+          name: doc


### PR DESCRIPTION
This pull request fixes the artifact name for the doc folder. Previously, it was not correctly named, causing confusion. Now, the artifact name is set to "doc" to accurately reflect the contents of the folder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Chores**
	- Improved artifact naming for documentation in CI workflows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->