### PR TITLE
Fix Dockerfile syntax error in .devcontainer/Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,5 +2,5 @@ FROM mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye@sha256:76fea4
 
 RUN apt-get update && apt-get install -y graphviz && \
     curl -fsSL https://deno.land/x/install/install.sh | sh && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* \
     curl -fsSL https://deno.land/x/install/install.sh | sh

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,5 +2,5 @@ FROM mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye@sha256:76fea4
 
 RUN apt-get update && apt-get install -y graphviz && \
     curl -fsSL https://deno.land/x/install/install.sh | sh && \
-    rm -rf /var/lib/apt/lists/* \
+    rm -rf /var/lib/apt/lists/* && \
     curl -fsSL https://deno.land/x/install/install.sh | sh


### PR DESCRIPTION
This pull request fixes a syntax error in the .devcontainer/Dockerfile. The error was causing the build to fail. The fix involves removing a backslash that was mistakenly placed before the "curl" command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Modified the Docker environment setup to include the installation of Deno, enhancing the development container capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->