### PR TITLE
Support Node.js v22

### DIFF
--- a/.changeset/eight-days-watch.md
+++ b/.changeset/eight-days-watch.md
@@ -1,0 +1,10 @@
+---
+"@ts-graphviz/adapter": patch
+"@ts-graphviz/ast": patch
+"@ts-graphviz/common": patch
+"@ts-graphviz/core": patch
+"@ts-graphviz/react": patch
+"ts-graphviz": patch
+---
+
+Support Node.js v22

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
     - name: Harden Runner


### PR DESCRIPTION
Add support for Node.js v22 as it is released.

No changes were relevant to the ts-graphviz project, so we ensured that it was tested on Node.js v22 in CI.

- [Node.js 22 is now available!](https://nodejs.org/en/blog/announcements/v22-release-announce)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for Node.js version 22 to ensure compatibility and enhanced performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->