### PR TITLE
Update React devDependencies and fix types

### DIFF
--- a/.changeset/empty-chairs-admire.md
+++ b/.changeset/empty-chairs-admire.md
@@ -1,0 +1,5 @@
+---
+"@ts-graphviz/react": patch
+---
+
+Update React devDependencies and fix types.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -50,12 +50,12 @@
   },
   "devDependencies": {
     "@testing-library/react": "^14.2.1",
-    "@types/react": "^18.2.65",
-    "@types/react-dom": "^18.2.22",
-    "@types/react-reconciler": "^0.26.7",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-test-renderer": "^18.2.0",
+    "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.0",
+    "@types/react-reconciler": "^0.28.8",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-test-renderer": "^18.3.1",
     "typescript": "^5.4.5",
     "vite": "^5.2.8",
     "vite-plugin-dts": "^3.7.3"

--- a/packages/react/src/reconciler.ts
+++ b/packages/react/src/reconciler.ts
@@ -1,6 +1,7 @@
 import type { FC } from 'react';
 import ReactReconciler from 'react-reconciler';
-
+// @ts-ignore
+import { DefaultEventPriority } from 'react-reconciler/constants';
 type Type = FC;
 type Props = any;
 type Container = Record<string, never>;
@@ -36,6 +37,34 @@ export class HostConfig
       NoTimeout
     >
 {
+  getCurrentEventPriority(): number {
+    return DefaultEventPriority;
+  }
+
+  getInstanceFromNode(node: any): ReactReconciler.Fiber | null | undefined {
+    return null;
+  }
+
+  beforeActiveInstanceBlur(): void {
+    // NoOp
+  }
+
+  afterActiveInstanceBlur(): void {
+    // NoOp
+  }
+
+  prepareScopeUpdate(scopeInstance: any, instance: any): void {
+    // NoOp
+  }
+
+  getInstanceFromScope(scopeInstance: any) {
+    // NoOp
+  }
+
+  detachDeletedInstance(node: any): void {
+    // NoOp
+  }
+
   preparePortalMount(containerInfo: Container): void {
     // NoOp
   }

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -8,6 +8,7 @@ import type {
   SubgraphAttributesObject,
 } from '@ts-graphviz/common';
 import type { ReactElement, ReactNode } from 'react';
+export type { ReactNode } from 'react';
 
 /** Common attribute values of objects under cluster */
 export interface GraphBaseAttributesProps {
@@ -83,7 +84,12 @@ export interface GraphPortalProps {
   children?: ReactNode;
 }
 
-declare global {
+/**
+ * Namespaced JSX elements for React.
+ *
+ * See details for <https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript>
+ */
+declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
       'dot:port': { children: string };

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -26,7 +26,13 @@ export default defineConfig({
   plugins: [
     // @ts-ignore
     dts({
-      rollupTypes: true,
+      /**
+       * Note: This option is not working properly.
+       * API Extractor cannot export "declare module ..." types.
+       *
+       * See detail for https://github.com/microsoft/rushstack/issues/2090
+       */
+      // rollupTypes: true,
     }),
   ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,32 +244,32 @@ importers:
         version: link:../common
       react-reconciler:
         specifier: ^0.29.0
-        version: 0.29.0(react@18.2.0)
+        version: 0.29.0(react@18.3.1)
       ts-graphviz:
         specifier: workspace:^
         version: link:../ts-graphviz
     devDependencies:
       '@testing-library/react':
         specifier: ^14.2.1
-        version: 14.2.1(react-dom@18.2.0)(react@18.2.0)
+        version: 14.2.1(react-dom@18.3.1)(react@18.3.1)
       '@types/react':
-        specifier: ^18.2.65
-        version: 18.2.66
+        specifier: ^18.3.1
+        version: 18.3.1
       '@types/react-dom':
-        specifier: ^18.2.22
-        version: 18.2.22
+        specifier: ^18.3.0
+        version: 18.3.0
       '@types/react-reconciler':
-        specifier: ^0.26.7
-        version: 0.26.7
+        specifier: ^0.28.8
+        version: 0.28.8
       react:
-        specifier: ^18.2.0
-        version: 18.2.0
+        specifier: ^18.3.1
+        version: 18.3.1
       react-dom:
-        specifier: ^18.2.0
-        version: 18.2.0(react@18.2.0)
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
       react-test-renderer:
-        specifier: ^18.2.0
-        version: 18.2.0(react@18.2.0)
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
       typescript:
         specifier: ^5.4.5
         version: 5.4.5
@@ -2174,7 +2174,7 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@testing-library/react@14.2.1(react-dom@18.2.0)(react@18.2.0):
+  /@testing-library/react@14.2.1(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-sGdjws32ai5TLerhvzThYFbpnF9XtL65Cjf+gB0Dhr29BGqK+mAeN7SURSdu+eqgET4ANcWoC7FQpkaiGvBr+A==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -2183,9 +2183,9 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.9
       '@testing-library/dom': 9.3.4
-      '@types/react-dom': 18.2.22
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      '@types/react-dom': 18.3.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
     dev: true
 
   /@tootallnate/once@1.1.2:
@@ -2289,16 +2289,16 @@ packages:
     resolution: {integrity: sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==}
     dev: true
 
-  /@types/react-dom@18.2.22:
-    resolution: {integrity: sha512-fHkBXPeNtfvri6gdsMYyW+dW7RXFo6Ad09nLFK0VQWR7yGLai/Cyvyj696gbwYvBnhGtevUG9cET0pmUbMtoPQ==}
+  /@types/react-dom@18.3.0:
+    resolution: {integrity: sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==}
     dependencies:
-      '@types/react': 18.2.66
+      '@types/react': 18.3.1
     dev: true
 
-  /@types/react-reconciler@0.26.7:
-    resolution: {integrity: sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ==}
+  /@types/react-reconciler@0.28.8:
+    resolution: {integrity: sha512-SN9c4kxXZonFhbX4hJrZy37yw9e7EIxcpHCxQv5JUS18wDE5ovkQKlqQEkufdJCCMfuI9BnjUJvhYeJ9x5Ra7g==}
     dependencies:
-      '@types/react': 18.2.66
+      '@types/react': 18.3.1
     dev: true
 
   /@types/react@18.2.66:
@@ -2306,6 +2306,13 @@ packages:
     dependencies:
       '@types/prop-types': 15.7.11
       '@types/scheduler': 0.16.8
+      csstype: 3.1.3
+    dev: true
+
+  /@types/react@18.3.1:
+    resolution: {integrity: sha512-V0kuGBX3+prX+DQ/7r2qsv1NsdfnCLnTgnRJ1pYnxykBhGMz+qj+box5lq7XsO5mtZsBqpjwwTu/7wszPfMBcw==}
+    dependencies:
+      '@types/prop-types': 15.7.11
       csstype: 3.1.3
     dev: true
 
@@ -6857,6 +6864,16 @@ packages:
       scheduler: 0.23.0
     dev: true
 
+  /react-dom@18.3.1(react@18.3.1):
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+    dev: true
+
   /react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
     dev: true
@@ -6865,40 +6882,51 @@ packages:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
 
-  /react-reconciler@0.29.0(react@18.2.0):
+  /react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+    dev: true
+
+  /react-reconciler@0.29.0(react@18.3.1):
     resolution: {integrity: sha512-wa0fGj7Zht1EYMRhKWwoo1H9GApxYLBuhoAuXN0TlltESAjDssB+Apf0T/DngVqaMyPypDmabL37vw/2aRM98Q==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
       react: ^18.2.0
     dependencies:
       loose-envify: 1.4.0
-      react: 18.2.0
+      react: 18.3.1
       scheduler: 0.23.0
     dev: false
 
-  /react-shallow-renderer@16.15.0(react@18.2.0):
+  /react-shallow-renderer@16.15.0(react@18.3.1):
     resolution: {integrity: sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==}
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0
     dependencies:
       object-assign: 4.1.1
-      react: 18.2.0
-      react-is: 18.2.0
+      react: 18.3.1
+      react-is: 18.3.1
     dev: true
 
-  /react-test-renderer@18.2.0(react@18.2.0):
-    resolution: {integrity: sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==}
+  /react-test-renderer@18.3.1(react@18.3.1):
+    resolution: {integrity: sha512-KkAgygexHUkQqtvvx/otwxtuFu5cVjfzTCtjXLH9boS19/Nbtg84zS7wIQn39G8IlrhThBpQsMKkq5ZHZIYFXA==}
     peerDependencies:
-      react: ^18.2.0
+      react: ^18.3.1
     dependencies:
-      react: 18.2.0
-      react-is: 18.2.0
-      react-shallow-renderer: 16.15.0(react@18.2.0)
-      scheduler: 0.23.0
+      react: 18.3.1
+      react-is: 18.3.1
+      react-shallow-renderer: 16.15.0(react@18.3.1)
+      scheduler: 0.23.2
     dev: true
 
   /react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: true
+
+  /react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
@@ -7245,6 +7273,12 @@ packages:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
     dependencies:
       loose-envify: 1.4.0
+
+  /scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: true
 
   /schema-utils@3.3.0:
     resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}


### PR DESCRIPTION
This pull request updates the React devDependencies in packages/react/package.json and fixes the @ts-graphviz/react rollupTypes option in vite.config.ts. It also updates the React types export. Additionally, a changeset has been added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the export of `ReactNode` and updated the declaration of JSX elements to support 'dot:port' with a children property of type string in React types.
- **Updates**
  - Updated dependencies including React, React DOM, TypeScript, and associated type definitions to their newer versions.
- **Configuration Changes**
  - Temporarily disabled the `rollupTypes` option in the Vite configuration due to issues with API Extractor, enhancing stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->