### PR TITLE
Fix global types exports issue

### DIFF
--- a/.changeset/mighty-hotels-cross.md
+++ b/.changeset/mighty-hotels-cross.md
@@ -1,0 +1,5 @@
+---
+"@ts-graphviz/react": patch
+---
+
+Fix global JSX type

--- a/.github/workflows/pr-snapshot-release.yaml
+++ b/.github/workflows/pr-snapshot-release.yaml
@@ -104,7 +104,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: 20
+          node-version-file: ./.node-version
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/pr-snapshot-release.yaml
+++ b/.github/workflows/pr-snapshot-release.yaml
@@ -106,8 +106,6 @@ jobs:
         with:
           node-version: 20
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
-        with:
-          version: 8
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -26,7 +26,8 @@ export default defineConfig({
   plugins: [
     // @ts-ignore
     dts({
-      rollupTypes: true,
+      // NOTE: This is a workaround for global types exports.
+      rollupTypes: false,
     }),
   ],
 });


### PR DESCRIPTION
Disable rollupTypes in packages/react/vite.config.ts to fix global types exports issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated internal build and configuration files for improved compatibility and workflow management. 

<!-- end of auto-generated comment: release notes by coderabbit.ai -->