### PR TITLE
Fix EdgeTargets validation in toNodeRefGroup function

### DIFF
--- a/.changeset/hip-mirrors-flash.md
+++ b/.changeset/hip-mirrors-flash.md
@@ -1,0 +1,5 @@
+---
+"@ts-graphviz/common": patch
+---
+
+Fix EdgeTargets validation in toNodeRefGroup function

--- a/packages/common/src/models.ts
+++ b/packages/common/src/models.ts
@@ -779,11 +779,13 @@ export function toNodeRef(target: NodeRefLike): NodeRef {
 
 /** @hidden */
 export function toNodeRefGroup(targets: NodeRefGroupLike): NodeRefGroup {
-  if (
-    targets.length < 2 &&
-    (isNodeRefLike(targets[0]) && isNodeRefLike(targets[1])) === false
-  ) {
-    throw Error('EdgeTargets must have at least 2 elements.');
+  if (targets.length < 1) {
+    throw Error('EdgeTargets must have at least 1 elements.');
+  }
+  if (!targets.every((target) => isNodeRefLike(target))) {
+    throw Error(
+      'The element of Edge target is missing or not satisfied as Edge target.',
+    );
   }
   return targets.map((t) => toNodeRef(t));
 }

--- a/test/dot/issue1147.dot
+++ b/test/dot/issue1147.dot
@@ -1,0 +1,31 @@
+digraph G {
+    node [shape=box, style=rounded];
+
+    P [label="P"];
+
+    C [shape=hexagon, style=filled, fillcolor=lightgreen];
+    Q [shape=hexagon, style=filled, fillcolor=lightcoral];
+
+    // Element nodes
+    C1 [label="C1"];
+    C2 [label="C2"];
+    C3 [label="C3"];
+
+    Q1 [label="Q1"];
+    Q2 [label="Q2"];
+    Q3 [label="Q3"];
+
+    P -> {C, Q} [style=dotted];
+
+    C -> {C1, C2, C3};
+    Q -> {Q1, Q2, Q3};
+
+    C1 -> {Q2, Q3};
+    C2 -> {Q3};
+    C3 -> {Q1, Q3};
+
+    // Invisible edges for layout
+    {rank=source; C Q}
+    {rank=same; C1 C2 C3}
+    {rank=same; Q1 Q2 Q3}
+}

--- a/test/dot/issue1147.snapshot
+++ b/test/dot/issue1147.snapshot
@@ -1,0 +1,2741 @@
+{
+  "children": [
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [],
+              "key": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 16,
+                    "line": 2,
+                    "offset": 27,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 11,
+                    "line": 2,
+                    "offset": 22,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "shape",
+              },
+              "location": {
+                "end": {
+                  "column": 21,
+                  "line": 2,
+                  "offset": 32,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 11,
+                  "line": 2,
+                  "offset": 22,
+                },
+              },
+              "type": "Attribute",
+              "value": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 20,
+                    "line": 2,
+                    "offset": 31,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 17,
+                    "line": 2,
+                    "offset": 28,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "box",
+              },
+            },
+            {
+              "children": [],
+              "key": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 27,
+                    "line": 2,
+                    "offset": 38,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 22,
+                    "line": 2,
+                    "offset": 33,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "style",
+              },
+              "location": {
+                "end": {
+                  "column": 35,
+                  "line": 2,
+                  "offset": 46,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 22,
+                  "line": 2,
+                  "offset": 33,
+                },
+              },
+              "type": "Attribute",
+              "value": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 35,
+                    "line": 2,
+                    "offset": 46,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 28,
+                    "line": 2,
+                    "offset": 39,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "rounded",
+              },
+            },
+          ],
+          "kind": "Node",
+          "location": {
+            "end": {
+              "column": 37,
+              "line": 2,
+              "offset": 48,
+            },
+            "source": undefined,
+            "start": {
+              "column": 5,
+              "line": 2,
+              "offset": 16,
+            },
+          },
+          "type": "AttributeList",
+        },
+        {
+          "children": [
+            {
+              "children": [],
+              "key": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 13,
+                    "line": 4,
+                    "offset": 62,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 8,
+                    "line": 4,
+                    "offset": 57,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "label",
+              },
+              "location": {
+                "end": {
+                  "column": 17,
+                  "line": 4,
+                  "offset": 66,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 8,
+                  "line": 4,
+                  "offset": 57,
+                },
+              },
+              "type": "Attribute",
+              "value": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 17,
+                    "line": 4,
+                    "offset": 66,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 14,
+                    "line": 4,
+                    "offset": 63,
+                  },
+                },
+                "quoted": true,
+                "type": "Literal",
+                "value": "P",
+              },
+            },
+          ],
+          "id": {
+            "children": [],
+            "location": {
+              "end": {
+                "column": 6,
+                "line": 4,
+                "offset": 55,
+              },
+              "source": undefined,
+              "start": {
+                "column": 5,
+                "line": 4,
+                "offset": 54,
+              },
+            },
+            "quoted": false,
+            "type": "Literal",
+            "value": "P",
+          },
+          "location": {
+            "end": {
+              "column": 19,
+              "line": 4,
+              "offset": 68,
+            },
+            "source": undefined,
+            "start": {
+              "column": 5,
+              "line": 4,
+              "offset": 54,
+            },
+          },
+          "type": "Node",
+        },
+        {
+          "children": [
+            {
+              "children": [],
+              "key": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 13,
+                    "line": 6,
+                    "offset": 82,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 8,
+                    "line": 6,
+                    "offset": 77,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "shape",
+              },
+              "location": {
+                "end": {
+                  "column": 22,
+                  "line": 6,
+                  "offset": 91,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 8,
+                  "line": 6,
+                  "offset": 77,
+                },
+              },
+              "type": "Attribute",
+              "value": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 21,
+                    "line": 6,
+                    "offset": 90,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 14,
+                    "line": 6,
+                    "offset": 83,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "hexagon",
+              },
+            },
+            {
+              "children": [],
+              "key": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 28,
+                    "line": 6,
+                    "offset": 97,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 23,
+                    "line": 6,
+                    "offset": 92,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "style",
+              },
+              "location": {
+                "end": {
+                  "column": 36,
+                  "line": 6,
+                  "offset": 105,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 23,
+                  "line": 6,
+                  "offset": 92,
+                },
+              },
+              "type": "Attribute",
+              "value": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 35,
+                    "line": 6,
+                    "offset": 104,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 29,
+                    "line": 6,
+                    "offset": 98,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "filled",
+              },
+            },
+            {
+              "children": [],
+              "key": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 46,
+                    "line": 6,
+                    "offset": 115,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 37,
+                    "line": 6,
+                    "offset": 106,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "fillcolor",
+              },
+              "location": {
+                "end": {
+                  "column": 57,
+                  "line": 6,
+                  "offset": 126,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 37,
+                  "line": 6,
+                  "offset": 106,
+                },
+              },
+              "type": "Attribute",
+              "value": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 57,
+                    "line": 6,
+                    "offset": 126,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 47,
+                    "line": 6,
+                    "offset": 116,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "lightgreen",
+              },
+            },
+          ],
+          "id": {
+            "children": [],
+            "location": {
+              "end": {
+                "column": 6,
+                "line": 6,
+                "offset": 75,
+              },
+              "source": undefined,
+              "start": {
+                "column": 5,
+                "line": 6,
+                "offset": 74,
+              },
+            },
+            "quoted": false,
+            "type": "Literal",
+            "value": "C",
+          },
+          "location": {
+            "end": {
+              "column": 59,
+              "line": 6,
+              "offset": 128,
+            },
+            "source": undefined,
+            "start": {
+              "column": 5,
+              "line": 6,
+              "offset": 74,
+            },
+          },
+          "type": "Node",
+        },
+        {
+          "children": [
+            {
+              "children": [],
+              "key": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 13,
+                    "line": 7,
+                    "offset": 141,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 8,
+                    "line": 7,
+                    "offset": 136,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "shape",
+              },
+              "location": {
+                "end": {
+                  "column": 22,
+                  "line": 7,
+                  "offset": 150,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 8,
+                  "line": 7,
+                  "offset": 136,
+                },
+              },
+              "type": "Attribute",
+              "value": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 21,
+                    "line": 7,
+                    "offset": 149,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 14,
+                    "line": 7,
+                    "offset": 142,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "hexagon",
+              },
+            },
+            {
+              "children": [],
+              "key": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 28,
+                    "line": 7,
+                    "offset": 156,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 23,
+                    "line": 7,
+                    "offset": 151,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "style",
+              },
+              "location": {
+                "end": {
+                  "column": 36,
+                  "line": 7,
+                  "offset": 164,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 23,
+                  "line": 7,
+                  "offset": 151,
+                },
+              },
+              "type": "Attribute",
+              "value": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 35,
+                    "line": 7,
+                    "offset": 163,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 29,
+                    "line": 7,
+                    "offset": 157,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "filled",
+              },
+            },
+            {
+              "children": [],
+              "key": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 46,
+                    "line": 7,
+                    "offset": 174,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 37,
+                    "line": 7,
+                    "offset": 165,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "fillcolor",
+              },
+              "location": {
+                "end": {
+                  "column": 57,
+                  "line": 7,
+                  "offset": 185,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 37,
+                  "line": 7,
+                  "offset": 165,
+                },
+              },
+              "type": "Attribute",
+              "value": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 57,
+                    "line": 7,
+                    "offset": 185,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 47,
+                    "line": 7,
+                    "offset": 175,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "lightcoral",
+              },
+            },
+          ],
+          "id": {
+            "children": [],
+            "location": {
+              "end": {
+                "column": 6,
+                "line": 7,
+                "offset": 134,
+              },
+              "source": undefined,
+              "start": {
+                "column": 5,
+                "line": 7,
+                "offset": 133,
+              },
+            },
+            "quoted": false,
+            "type": "Literal",
+            "value": "Q",
+          },
+          "location": {
+            "end": {
+              "column": 59,
+              "line": 7,
+              "offset": 187,
+            },
+            "source": undefined,
+            "start": {
+              "column": 5,
+              "line": 7,
+              "offset": 133,
+            },
+          },
+          "type": "Node",
+        },
+        {
+          "children": [],
+          "kind": "Slash",
+          "location": {
+            "end": {
+              "column": 1,
+              "line": 10,
+              "offset": 210,
+            },
+            "source": undefined,
+            "start": {
+              "column": 5,
+              "line": 9,
+              "offset": 193,
+            },
+          },
+          "type": "Comment",
+          "value": "Element nodes",
+        },
+        {
+          "children": [
+            {
+              "children": [],
+              "key": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 14,
+                    "line": 10,
+                    "offset": 223,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 9,
+                    "line": 10,
+                    "offset": 218,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "label",
+              },
+              "location": {
+                "end": {
+                  "column": 19,
+                  "line": 10,
+                  "offset": 228,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 9,
+                  "line": 10,
+                  "offset": 218,
+                },
+              },
+              "type": "Attribute",
+              "value": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 19,
+                    "line": 10,
+                    "offset": 228,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 15,
+                    "line": 10,
+                    "offset": 224,
+                  },
+                },
+                "quoted": true,
+                "type": "Literal",
+                "value": "C1",
+              },
+            },
+          ],
+          "id": {
+            "children": [],
+            "location": {
+              "end": {
+                "column": 7,
+                "line": 10,
+                "offset": 216,
+              },
+              "source": undefined,
+              "start": {
+                "column": 5,
+                "line": 10,
+                "offset": 214,
+              },
+            },
+            "quoted": false,
+            "type": "Literal",
+            "value": "C1",
+          },
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 10,
+              "offset": 230,
+            },
+            "source": undefined,
+            "start": {
+              "column": 5,
+              "line": 10,
+              "offset": 214,
+            },
+          },
+          "type": "Node",
+        },
+        {
+          "children": [
+            {
+              "children": [],
+              "key": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 14,
+                    "line": 11,
+                    "offset": 244,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 9,
+                    "line": 11,
+                    "offset": 239,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "label",
+              },
+              "location": {
+                "end": {
+                  "column": 19,
+                  "line": 11,
+                  "offset": 249,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 9,
+                  "line": 11,
+                  "offset": 239,
+                },
+              },
+              "type": "Attribute",
+              "value": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 19,
+                    "line": 11,
+                    "offset": 249,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 15,
+                    "line": 11,
+                    "offset": 245,
+                  },
+                },
+                "quoted": true,
+                "type": "Literal",
+                "value": "C2",
+              },
+            },
+          ],
+          "id": {
+            "children": [],
+            "location": {
+              "end": {
+                "column": 7,
+                "line": 11,
+                "offset": 237,
+              },
+              "source": undefined,
+              "start": {
+                "column": 5,
+                "line": 11,
+                "offset": 235,
+              },
+            },
+            "quoted": false,
+            "type": "Literal",
+            "value": "C2",
+          },
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 11,
+              "offset": 251,
+            },
+            "source": undefined,
+            "start": {
+              "column": 5,
+              "line": 11,
+              "offset": 235,
+            },
+          },
+          "type": "Node",
+        },
+        {
+          "children": [
+            {
+              "children": [],
+              "key": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 14,
+                    "line": 12,
+                    "offset": 265,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 9,
+                    "line": 12,
+                    "offset": 260,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "label",
+              },
+              "location": {
+                "end": {
+                  "column": 19,
+                  "line": 12,
+                  "offset": 270,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 9,
+                  "line": 12,
+                  "offset": 260,
+                },
+              },
+              "type": "Attribute",
+              "value": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 19,
+                    "line": 12,
+                    "offset": 270,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 15,
+                    "line": 12,
+                    "offset": 266,
+                  },
+                },
+                "quoted": true,
+                "type": "Literal",
+                "value": "C3",
+              },
+            },
+          ],
+          "id": {
+            "children": [],
+            "location": {
+              "end": {
+                "column": 7,
+                "line": 12,
+                "offset": 258,
+              },
+              "source": undefined,
+              "start": {
+                "column": 5,
+                "line": 12,
+                "offset": 256,
+              },
+            },
+            "quoted": false,
+            "type": "Literal",
+            "value": "C3",
+          },
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 12,
+              "offset": 272,
+            },
+            "source": undefined,
+            "start": {
+              "column": 5,
+              "line": 12,
+              "offset": 256,
+            },
+          },
+          "type": "Node",
+        },
+        {
+          "children": [
+            {
+              "children": [],
+              "key": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 14,
+                    "line": 14,
+                    "offset": 287,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 9,
+                    "line": 14,
+                    "offset": 282,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "label",
+              },
+              "location": {
+                "end": {
+                  "column": 19,
+                  "line": 14,
+                  "offset": 292,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 9,
+                  "line": 14,
+                  "offset": 282,
+                },
+              },
+              "type": "Attribute",
+              "value": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 19,
+                    "line": 14,
+                    "offset": 292,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 15,
+                    "line": 14,
+                    "offset": 288,
+                  },
+                },
+                "quoted": true,
+                "type": "Literal",
+                "value": "Q1",
+              },
+            },
+          ],
+          "id": {
+            "children": [],
+            "location": {
+              "end": {
+                "column": 7,
+                "line": 14,
+                "offset": 280,
+              },
+              "source": undefined,
+              "start": {
+                "column": 5,
+                "line": 14,
+                "offset": 278,
+              },
+            },
+            "quoted": false,
+            "type": "Literal",
+            "value": "Q1",
+          },
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 14,
+              "offset": 294,
+            },
+            "source": undefined,
+            "start": {
+              "column": 5,
+              "line": 14,
+              "offset": 278,
+            },
+          },
+          "type": "Node",
+        },
+        {
+          "children": [
+            {
+              "children": [],
+              "key": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 14,
+                    "line": 15,
+                    "offset": 308,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 9,
+                    "line": 15,
+                    "offset": 303,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "label",
+              },
+              "location": {
+                "end": {
+                  "column": 19,
+                  "line": 15,
+                  "offset": 313,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 9,
+                  "line": 15,
+                  "offset": 303,
+                },
+              },
+              "type": "Attribute",
+              "value": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 19,
+                    "line": 15,
+                    "offset": 313,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 15,
+                    "line": 15,
+                    "offset": 309,
+                  },
+                },
+                "quoted": true,
+                "type": "Literal",
+                "value": "Q2",
+              },
+            },
+          ],
+          "id": {
+            "children": [],
+            "location": {
+              "end": {
+                "column": 7,
+                "line": 15,
+                "offset": 301,
+              },
+              "source": undefined,
+              "start": {
+                "column": 5,
+                "line": 15,
+                "offset": 299,
+              },
+            },
+            "quoted": false,
+            "type": "Literal",
+            "value": "Q2",
+          },
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 15,
+              "offset": 315,
+            },
+            "source": undefined,
+            "start": {
+              "column": 5,
+              "line": 15,
+              "offset": 299,
+            },
+          },
+          "type": "Node",
+        },
+        {
+          "children": [
+            {
+              "children": [],
+              "key": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 14,
+                    "line": 16,
+                    "offset": 329,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 9,
+                    "line": 16,
+                    "offset": 324,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "label",
+              },
+              "location": {
+                "end": {
+                  "column": 19,
+                  "line": 16,
+                  "offset": 334,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 9,
+                  "line": 16,
+                  "offset": 324,
+                },
+              },
+              "type": "Attribute",
+              "value": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 19,
+                    "line": 16,
+                    "offset": 334,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 15,
+                    "line": 16,
+                    "offset": 330,
+                  },
+                },
+                "quoted": true,
+                "type": "Literal",
+                "value": "Q3",
+              },
+            },
+          ],
+          "id": {
+            "children": [],
+            "location": {
+              "end": {
+                "column": 7,
+                "line": 16,
+                "offset": 322,
+              },
+              "source": undefined,
+              "start": {
+                "column": 5,
+                "line": 16,
+                "offset": 320,
+              },
+            },
+            "quoted": false,
+            "type": "Literal",
+            "value": "Q3",
+          },
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 16,
+              "offset": 336,
+            },
+            "source": undefined,
+            "start": {
+              "column": 5,
+              "line": 16,
+              "offset": 320,
+            },
+          },
+          "type": "Node",
+        },
+        {
+          "children": [
+            {
+              "children": [],
+              "key": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 23,
+                    "line": 18,
+                    "offset": 360,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 18,
+                    "line": 18,
+                    "offset": 355,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "style",
+              },
+              "location": {
+                "end": {
+                  "column": 30,
+                  "line": 18,
+                  "offset": 367,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 18,
+                  "line": 18,
+                  "offset": 355,
+                },
+              },
+              "type": "Attribute",
+              "value": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 30,
+                    "line": 18,
+                    "offset": 367,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 24,
+                    "line": 18,
+                    "offset": 361,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "dotted",
+              },
+            },
+          ],
+          "location": {
+            "end": {
+              "column": 32,
+              "line": 18,
+              "offset": 369,
+            },
+            "source": undefined,
+            "start": {
+              "column": 5,
+              "line": 18,
+              "offset": 342,
+            },
+          },
+          "targets": [
+            {
+              "children": [],
+              "id": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 6,
+                    "line": 18,
+                    "offset": 343,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 5,
+                    "line": 18,
+                    "offset": 342,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "P",
+              },
+              "location": {
+                "end": {
+                  "column": 6,
+                  "line": 18,
+                  "offset": 343,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 5,
+                  "line": 18,
+                  "offset": 342,
+                },
+              },
+              "type": "NodeRef",
+            },
+            {
+              "children": [
+                {
+                  "children": [],
+                  "id": {
+                    "children": [],
+                    "location": {
+                      "end": {
+                        "column": 12,
+                        "line": 18,
+                        "offset": 349,
+                      },
+                      "source": undefined,
+                      "start": {
+                        "column": 11,
+                        "line": 18,
+                        "offset": 348,
+                      },
+                    },
+                    "quoted": false,
+                    "type": "Literal",
+                    "value": "C",
+                  },
+                  "location": {
+                    "end": {
+                      "column": 12,
+                      "line": 18,
+                      "offset": 349,
+                    },
+                    "source": undefined,
+                    "start": {
+                      "column": 11,
+                      "line": 18,
+                      "offset": 348,
+                    },
+                  },
+                  "type": "NodeRef",
+                },
+                {
+                  "children": [],
+                  "id": {
+                    "children": [],
+                    "location": {
+                      "end": {
+                        "column": 15,
+                        "line": 18,
+                        "offset": 352,
+                      },
+                      "source": undefined,
+                      "start": {
+                        "column": 14,
+                        "line": 18,
+                        "offset": 351,
+                      },
+                    },
+                    "quoted": false,
+                    "type": "Literal",
+                    "value": "Q",
+                  },
+                  "location": {
+                    "end": {
+                      "column": 15,
+                      "line": 18,
+                      "offset": 352,
+                    },
+                    "source": undefined,
+                    "start": {
+                      "column": 14,
+                      "line": 18,
+                      "offset": 351,
+                    },
+                  },
+                  "type": "NodeRef",
+                },
+              ],
+              "location": {
+                "end": {
+                  "column": 16,
+                  "line": 18,
+                  "offset": 353,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 10,
+                  "line": 18,
+                  "offset": 347,
+                },
+              },
+              "type": "NodeRefGroup",
+            },
+          ],
+          "type": "Edge",
+        },
+        {
+          "children": [],
+          "location": {
+            "end": {
+              "column": 23,
+              "line": 20,
+              "offset": 393,
+            },
+            "source": undefined,
+            "start": {
+              "column": 5,
+              "line": 20,
+              "offset": 375,
+            },
+          },
+          "targets": [
+            {
+              "children": [],
+              "id": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 6,
+                    "line": 20,
+                    "offset": 376,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 5,
+                    "line": 20,
+                    "offset": 375,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "C",
+              },
+              "location": {
+                "end": {
+                  "column": 6,
+                  "line": 20,
+                  "offset": 376,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 5,
+                  "line": 20,
+                  "offset": 375,
+                },
+              },
+              "type": "NodeRef",
+            },
+            {
+              "children": [
+                {
+                  "children": [],
+                  "id": {
+                    "children": [],
+                    "location": {
+                      "end": {
+                        "column": 13,
+                        "line": 20,
+                        "offset": 383,
+                      },
+                      "source": undefined,
+                      "start": {
+                        "column": 11,
+                        "line": 20,
+                        "offset": 381,
+                      },
+                    },
+                    "quoted": false,
+                    "type": "Literal",
+                    "value": "C1",
+                  },
+                  "location": {
+                    "end": {
+                      "column": 13,
+                      "line": 20,
+                      "offset": 383,
+                    },
+                    "source": undefined,
+                    "start": {
+                      "column": 11,
+                      "line": 20,
+                      "offset": 381,
+                    },
+                  },
+                  "type": "NodeRef",
+                },
+                {
+                  "children": [],
+                  "id": {
+                    "children": [],
+                    "location": {
+                      "end": {
+                        "column": 17,
+                        "line": 20,
+                        "offset": 387,
+                      },
+                      "source": undefined,
+                      "start": {
+                        "column": 15,
+                        "line": 20,
+                        "offset": 385,
+                      },
+                    },
+                    "quoted": false,
+                    "type": "Literal",
+                    "value": "C2",
+                  },
+                  "location": {
+                    "end": {
+                      "column": 17,
+                      "line": 20,
+                      "offset": 387,
+                    },
+                    "source": undefined,
+                    "start": {
+                      "column": 15,
+                      "line": 20,
+                      "offset": 385,
+                    },
+                  },
+                  "type": "NodeRef",
+                },
+                {
+                  "children": [],
+                  "id": {
+                    "children": [],
+                    "location": {
+                      "end": {
+                        "column": 21,
+                        "line": 20,
+                        "offset": 391,
+                      },
+                      "source": undefined,
+                      "start": {
+                        "column": 19,
+                        "line": 20,
+                        "offset": 389,
+                      },
+                    },
+                    "quoted": false,
+                    "type": "Literal",
+                    "value": "C3",
+                  },
+                  "location": {
+                    "end": {
+                      "column": 21,
+                      "line": 20,
+                      "offset": 391,
+                    },
+                    "source": undefined,
+                    "start": {
+                      "column": 19,
+                      "line": 20,
+                      "offset": 389,
+                    },
+                  },
+                  "type": "NodeRef",
+                },
+              ],
+              "location": {
+                "end": {
+                  "column": 22,
+                  "line": 20,
+                  "offset": 392,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 10,
+                  "line": 20,
+                  "offset": 380,
+                },
+              },
+              "type": "NodeRefGroup",
+            },
+          ],
+          "type": "Edge",
+        },
+        {
+          "children": [],
+          "location": {
+            "end": {
+              "column": 23,
+              "line": 21,
+              "offset": 416,
+            },
+            "source": undefined,
+            "start": {
+              "column": 5,
+              "line": 21,
+              "offset": 398,
+            },
+          },
+          "targets": [
+            {
+              "children": [],
+              "id": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 6,
+                    "line": 21,
+                    "offset": 399,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 5,
+                    "line": 21,
+                    "offset": 398,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "Q",
+              },
+              "location": {
+                "end": {
+                  "column": 6,
+                  "line": 21,
+                  "offset": 399,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 5,
+                  "line": 21,
+                  "offset": 398,
+                },
+              },
+              "type": "NodeRef",
+            },
+            {
+              "children": [
+                {
+                  "children": [],
+                  "id": {
+                    "children": [],
+                    "location": {
+                      "end": {
+                        "column": 13,
+                        "line": 21,
+                        "offset": 406,
+                      },
+                      "source": undefined,
+                      "start": {
+                        "column": 11,
+                        "line": 21,
+                        "offset": 404,
+                      },
+                    },
+                    "quoted": false,
+                    "type": "Literal",
+                    "value": "Q1",
+                  },
+                  "location": {
+                    "end": {
+                      "column": 13,
+                      "line": 21,
+                      "offset": 406,
+                    },
+                    "source": undefined,
+                    "start": {
+                      "column": 11,
+                      "line": 21,
+                      "offset": 404,
+                    },
+                  },
+                  "type": "NodeRef",
+                },
+                {
+                  "children": [],
+                  "id": {
+                    "children": [],
+                    "location": {
+                      "end": {
+                        "column": 17,
+                        "line": 21,
+                        "offset": 410,
+                      },
+                      "source": undefined,
+                      "start": {
+                        "column": 15,
+                        "line": 21,
+                        "offset": 408,
+                      },
+                    },
+                    "quoted": false,
+                    "type": "Literal",
+                    "value": "Q2",
+                  },
+                  "location": {
+                    "end": {
+                      "column": 17,
+                      "line": 21,
+                      "offset": 410,
+                    },
+                    "source": undefined,
+                    "start": {
+                      "column": 15,
+                      "line": 21,
+                      "offset": 408,
+                    },
+                  },
+                  "type": "NodeRef",
+                },
+                {
+                  "children": [],
+                  "id": {
+                    "children": [],
+                    "location": {
+                      "end": {
+                        "column": 21,
+                        "line": 21,
+                        "offset": 414,
+                      },
+                      "source": undefined,
+                      "start": {
+                        "column": 19,
+                        "line": 21,
+                        "offset": 412,
+                      },
+                    },
+                    "quoted": false,
+                    "type": "Literal",
+                    "value": "Q3",
+                  },
+                  "location": {
+                    "end": {
+                      "column": 21,
+                      "line": 21,
+                      "offset": 414,
+                    },
+                    "source": undefined,
+                    "start": {
+                      "column": 19,
+                      "line": 21,
+                      "offset": 412,
+                    },
+                  },
+                  "type": "NodeRef",
+                },
+              ],
+              "location": {
+                "end": {
+                  "column": 22,
+                  "line": 21,
+                  "offset": 415,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 10,
+                  "line": 21,
+                  "offset": 403,
+                },
+              },
+              "type": "NodeRefGroup",
+            },
+          ],
+          "type": "Edge",
+        },
+        {
+          "children": [],
+          "location": {
+            "end": {
+              "column": 20,
+              "line": 23,
+              "offset": 437,
+            },
+            "source": undefined,
+            "start": {
+              "column": 5,
+              "line": 23,
+              "offset": 422,
+            },
+          },
+          "targets": [
+            {
+              "children": [],
+              "id": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 7,
+                    "line": 23,
+                    "offset": 424,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 5,
+                    "line": 23,
+                    "offset": 422,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "C1",
+              },
+              "location": {
+                "end": {
+                  "column": 7,
+                  "line": 23,
+                  "offset": 424,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 5,
+                  "line": 23,
+                  "offset": 422,
+                },
+              },
+              "type": "NodeRef",
+            },
+            {
+              "children": [
+                {
+                  "children": [],
+                  "id": {
+                    "children": [],
+                    "location": {
+                      "end": {
+                        "column": 14,
+                        "line": 23,
+                        "offset": 431,
+                      },
+                      "source": undefined,
+                      "start": {
+                        "column": 12,
+                        "line": 23,
+                        "offset": 429,
+                      },
+                    },
+                    "quoted": false,
+                    "type": "Literal",
+                    "value": "Q2",
+                  },
+                  "location": {
+                    "end": {
+                      "column": 14,
+                      "line": 23,
+                      "offset": 431,
+                    },
+                    "source": undefined,
+                    "start": {
+                      "column": 12,
+                      "line": 23,
+                      "offset": 429,
+                    },
+                  },
+                  "type": "NodeRef",
+                },
+                {
+                  "children": [],
+                  "id": {
+                    "children": [],
+                    "location": {
+                      "end": {
+                        "column": 18,
+                        "line": 23,
+                        "offset": 435,
+                      },
+                      "source": undefined,
+                      "start": {
+                        "column": 16,
+                        "line": 23,
+                        "offset": 433,
+                      },
+                    },
+                    "quoted": false,
+                    "type": "Literal",
+                    "value": "Q3",
+                  },
+                  "location": {
+                    "end": {
+                      "column": 18,
+                      "line": 23,
+                      "offset": 435,
+                    },
+                    "source": undefined,
+                    "start": {
+                      "column": 16,
+                      "line": 23,
+                      "offset": 433,
+                    },
+                  },
+                  "type": "NodeRef",
+                },
+              ],
+              "location": {
+                "end": {
+                  "column": 19,
+                  "line": 23,
+                  "offset": 436,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 11,
+                  "line": 23,
+                  "offset": 428,
+                },
+              },
+              "type": "NodeRefGroup",
+            },
+          ],
+          "type": "Edge",
+        },
+        {
+          "children": [],
+          "location": {
+            "end": {
+              "column": 16,
+              "line": 24,
+              "offset": 453,
+            },
+            "source": undefined,
+            "start": {
+              "column": 5,
+              "line": 24,
+              "offset": 442,
+            },
+          },
+          "targets": [
+            {
+              "children": [],
+              "id": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 7,
+                    "line": 24,
+                    "offset": 444,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 5,
+                    "line": 24,
+                    "offset": 442,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "C2",
+              },
+              "location": {
+                "end": {
+                  "column": 7,
+                  "line": 24,
+                  "offset": 444,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 5,
+                  "line": 24,
+                  "offset": 442,
+                },
+              },
+              "type": "NodeRef",
+            },
+            {
+              "children": [
+                {
+                  "children": [],
+                  "id": {
+                    "children": [],
+                    "location": {
+                      "end": {
+                        "column": 14,
+                        "line": 24,
+                        "offset": 451,
+                      },
+                      "source": undefined,
+                      "start": {
+                        "column": 12,
+                        "line": 24,
+                        "offset": 449,
+                      },
+                    },
+                    "quoted": false,
+                    "type": "Literal",
+                    "value": "Q3",
+                  },
+                  "location": {
+                    "end": {
+                      "column": 14,
+                      "line": 24,
+                      "offset": 451,
+                    },
+                    "source": undefined,
+                    "start": {
+                      "column": 12,
+                      "line": 24,
+                      "offset": 449,
+                    },
+                  },
+                  "type": "NodeRef",
+                },
+              ],
+              "location": {
+                "end": {
+                  "column": 15,
+                  "line": 24,
+                  "offset": 452,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 11,
+                  "line": 24,
+                  "offset": 448,
+                },
+              },
+              "type": "NodeRefGroup",
+            },
+          ],
+          "type": "Edge",
+        },
+        {
+          "children": [],
+          "location": {
+            "end": {
+              "column": 20,
+              "line": 25,
+              "offset": 473,
+            },
+            "source": undefined,
+            "start": {
+              "column": 5,
+              "line": 25,
+              "offset": 458,
+            },
+          },
+          "targets": [
+            {
+              "children": [],
+              "id": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 7,
+                    "line": 25,
+                    "offset": 460,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 5,
+                    "line": 25,
+                    "offset": 458,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "C3",
+              },
+              "location": {
+                "end": {
+                  "column": 7,
+                  "line": 25,
+                  "offset": 460,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 5,
+                  "line": 25,
+                  "offset": 458,
+                },
+              },
+              "type": "NodeRef",
+            },
+            {
+              "children": [
+                {
+                  "children": [],
+                  "id": {
+                    "children": [],
+                    "location": {
+                      "end": {
+                        "column": 14,
+                        "line": 25,
+                        "offset": 467,
+                      },
+                      "source": undefined,
+                      "start": {
+                        "column": 12,
+                        "line": 25,
+                        "offset": 465,
+                      },
+                    },
+                    "quoted": false,
+                    "type": "Literal",
+                    "value": "Q1",
+                  },
+                  "location": {
+                    "end": {
+                      "column": 14,
+                      "line": 25,
+                      "offset": 467,
+                    },
+                    "source": undefined,
+                    "start": {
+                      "column": 12,
+                      "line": 25,
+                      "offset": 465,
+                    },
+                  },
+                  "type": "NodeRef",
+                },
+                {
+                  "children": [],
+                  "id": {
+                    "children": [],
+                    "location": {
+                      "end": {
+                        "column": 18,
+                        "line": 25,
+                        "offset": 471,
+                      },
+                      "source": undefined,
+                      "start": {
+                        "column": 16,
+                        "line": 25,
+                        "offset": 469,
+                      },
+                    },
+                    "quoted": false,
+                    "type": "Literal",
+                    "value": "Q3",
+                  },
+                  "location": {
+                    "end": {
+                      "column": 18,
+                      "line": 25,
+                      "offset": 471,
+                    },
+                    "source": undefined,
+                    "start": {
+                      "column": 16,
+                      "line": 25,
+                      "offset": 469,
+                    },
+                  },
+                  "type": "NodeRef",
+                },
+              ],
+              "location": {
+                "end": {
+                  "column": 19,
+                  "line": 25,
+                  "offset": 472,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 11,
+                  "line": 25,
+                  "offset": 464,
+                },
+              },
+              "type": "NodeRefGroup",
+            },
+          ],
+          "type": "Edge",
+        },
+        {
+          "children": [],
+          "kind": "Slash",
+          "location": {
+            "end": {
+              "column": 1,
+              "line": 28,
+              "offset": 509,
+            },
+            "source": undefined,
+            "start": {
+              "column": 5,
+              "line": 27,
+              "offset": 479,
+            },
+          },
+          "type": "Comment",
+          "value": "Invisible edges for layout",
+        },
+        {
+          "children": [
+            {
+              "children": [],
+              "key": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 10,
+                    "line": 28,
+                    "offset": 518,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 6,
+                    "line": 28,
+                    "offset": 514,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "rank",
+              },
+              "location": {
+                "end": {
+                  "column": 18,
+                  "line": 28,
+                  "offset": 526,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 6,
+                  "line": 28,
+                  "offset": 514,
+                },
+              },
+              "type": "Attribute",
+              "value": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 17,
+                    "line": 28,
+                    "offset": 525,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 11,
+                    "line": 28,
+                    "offset": 519,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "source",
+              },
+            },
+            {
+              "children": [],
+              "id": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 20,
+                    "line": 28,
+                    "offset": 528,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 19,
+                    "line": 28,
+                    "offset": 527,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "C",
+              },
+              "location": {
+                "end": {
+                  "column": 21,
+                  "line": 28,
+                  "offset": 529,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 19,
+                  "line": 28,
+                  "offset": 527,
+                },
+              },
+              "type": "Node",
+            },
+            {
+              "children": [],
+              "id": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 22,
+                    "line": 28,
+                    "offset": 530,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 21,
+                    "line": 28,
+                    "offset": 529,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "Q",
+              },
+              "location": {
+                "end": {
+                  "column": 22,
+                  "line": 28,
+                  "offset": 530,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 21,
+                  "line": 28,
+                  "offset": 529,
+                },
+              },
+              "type": "Node",
+            },
+          ],
+          "location": {
+            "end": {
+              "column": 23,
+              "line": 28,
+              "offset": 531,
+            },
+            "source": undefined,
+            "start": {
+              "column": 5,
+              "line": 28,
+              "offset": 513,
+            },
+          },
+          "type": "Subgraph",
+        },
+        {
+          "children": [
+            {
+              "children": [],
+              "key": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 10,
+                    "line": 29,
+                    "offset": 541,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 6,
+                    "line": 29,
+                    "offset": 537,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "rank",
+              },
+              "location": {
+                "end": {
+                  "column": 16,
+                  "line": 29,
+                  "offset": 547,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 6,
+                  "line": 29,
+                  "offset": 537,
+                },
+              },
+              "type": "Attribute",
+              "value": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 15,
+                    "line": 29,
+                    "offset": 546,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 11,
+                    "line": 29,
+                    "offset": 542,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "same",
+              },
+            },
+            {
+              "children": [],
+              "id": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 19,
+                    "line": 29,
+                    "offset": 550,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 17,
+                    "line": 29,
+                    "offset": 548,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "C1",
+              },
+              "location": {
+                "end": {
+                  "column": 20,
+                  "line": 29,
+                  "offset": 551,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 17,
+                  "line": 29,
+                  "offset": 548,
+                },
+              },
+              "type": "Node",
+            },
+            {
+              "children": [],
+              "id": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 22,
+                    "line": 29,
+                    "offset": 553,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 20,
+                    "line": 29,
+                    "offset": 551,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "C2",
+              },
+              "location": {
+                "end": {
+                  "column": 23,
+                  "line": 29,
+                  "offset": 554,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 20,
+                  "line": 29,
+                  "offset": 551,
+                },
+              },
+              "type": "Node",
+            },
+            {
+              "children": [],
+              "id": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 25,
+                    "line": 29,
+                    "offset": 556,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 23,
+                    "line": 29,
+                    "offset": 554,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "C3",
+              },
+              "location": {
+                "end": {
+                  "column": 25,
+                  "line": 29,
+                  "offset": 556,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 23,
+                  "line": 29,
+                  "offset": 554,
+                },
+              },
+              "type": "Node",
+            },
+          ],
+          "location": {
+            "end": {
+              "column": 26,
+              "line": 29,
+              "offset": 557,
+            },
+            "source": undefined,
+            "start": {
+              "column": 5,
+              "line": 29,
+              "offset": 536,
+            },
+          },
+          "type": "Subgraph",
+        },
+        {
+          "children": [
+            {
+              "children": [],
+              "key": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 10,
+                    "line": 30,
+                    "offset": 567,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 6,
+                    "line": 30,
+                    "offset": 563,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "rank",
+              },
+              "location": {
+                "end": {
+                  "column": 16,
+                  "line": 30,
+                  "offset": 573,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 6,
+                  "line": 30,
+                  "offset": 563,
+                },
+              },
+              "type": "Attribute",
+              "value": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 15,
+                    "line": 30,
+                    "offset": 572,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 11,
+                    "line": 30,
+                    "offset": 568,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "same",
+              },
+            },
+            {
+              "children": [],
+              "id": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 19,
+                    "line": 30,
+                    "offset": 576,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 17,
+                    "line": 30,
+                    "offset": 574,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "Q1",
+              },
+              "location": {
+                "end": {
+                  "column": 20,
+                  "line": 30,
+                  "offset": 577,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 17,
+                  "line": 30,
+                  "offset": 574,
+                },
+              },
+              "type": "Node",
+            },
+            {
+              "children": [],
+              "id": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 22,
+                    "line": 30,
+                    "offset": 579,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 20,
+                    "line": 30,
+                    "offset": 577,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "Q2",
+              },
+              "location": {
+                "end": {
+                  "column": 23,
+                  "line": 30,
+                  "offset": 580,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 20,
+                  "line": 30,
+                  "offset": 577,
+                },
+              },
+              "type": "Node",
+            },
+            {
+              "children": [],
+              "id": {
+                "children": [],
+                "location": {
+                  "end": {
+                    "column": 25,
+                    "line": 30,
+                    "offset": 582,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 23,
+                    "line": 30,
+                    "offset": 580,
+                  },
+                },
+                "quoted": false,
+                "type": "Literal",
+                "value": "Q3",
+              },
+              "location": {
+                "end": {
+                  "column": 25,
+                  "line": 30,
+                  "offset": 582,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 23,
+                  "line": 30,
+                  "offset": 580,
+                },
+              },
+              "type": "Node",
+            },
+          ],
+          "location": {
+            "end": {
+              "column": 26,
+              "line": 30,
+              "offset": 583,
+            },
+            "source": undefined,
+            "start": {
+              "column": 5,
+              "line": 30,
+              "offset": 562,
+            },
+          },
+          "type": "Subgraph",
+        },
+      ],
+      "directed": true,
+      "id": {
+        "children": [],
+        "location": {
+          "end": {
+            "column": 10,
+            "line": 1,
+            "offset": 9,
+          },
+          "source": undefined,
+          "start": {
+            "column": 9,
+            "line": 1,
+            "offset": 8,
+          },
+        },
+        "quoted": false,
+        "type": "Literal",
+        "value": "G",
+      },
+      "location": {
+        "end": {
+          "column": 2,
+          "line": 31,
+          "offset": 585,
+        },
+        "source": undefined,
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "strict": false,
+      "type": "Graph",
+    },
+  ],
+  "location": {
+    "end": {
+      "column": 1,
+      "line": 32,
+      "offset": 586,
+    },
+    "source": undefined,
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "Dot",
+}

--- a/test/from-dot.test.ts
+++ b/test/from-dot.test.ts
@@ -66,3 +66,19 @@ test('partially described by DOT', () => {
     }"
   `);
 });
+
+test('edge to a group what contains only one target', () => {
+  const G = fromDot(
+    `digraph {
+      node_A -> { node_B };
+    }`,
+  );
+
+  expect(toDot(G)).toMatchInlineSnapshot(
+    `
+    "digraph {
+      "node_A" -> {"node_B"};
+    }"
+  `,
+  );
+});


### PR DESCRIPTION
This pull request fixes the validation of EdgeTargets in the toNodeRefGroup function.

Previously, the function required at least 2 elements in the EdgeTargets array, but this caused an error when trying to connect a group that contains only one target.
The fix updates the validation to allow a group with a single target. This resolves issue #1147.

fix #1147

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced validation logic for the `targets` parameter, allowing a minimum of one element while improving error handling for invalid inputs.
	- Introduced a new snapshot file for graph visualization, providing a structured representation of nodes and edges.

- **Tests**
	- Added a test case to validate the `fromDot` function for directed graphs with a single target node, expanding test coverage for graph processing functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->