### PR TITLE
Fix string escaping in DOT language

### DIFF
--- a/.changeset/brave-laws-attack.md
+++ b/.changeset/brave-laws-attack.md
@@ -1,0 +1,5 @@
+---
+"@ts-graphviz/ast": patch
+---
+
+Fix string escaping in DOT language

--- a/packages/ast/src/dot-shim/printer/plugins/utils/tokens.test.ts
+++ b/packages/ast/src/dot-shim/printer/plugins/utils/tokens.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'vitest';
+import { escape } from './tokens.js';
+
+describe('escape', () => {
+  test.each([
+    ['\r', '\\r'],
+    ['\n', '\\n'],
+    ['"', '\\"'],
+    [String.raw`a\la`, String.raw`a\la`],
+  ])('should escape %s to %s', (value, expected) => {
+    expect(escape(value)).toBe(expected);
+  });
+});

--- a/packages/ast/src/dot-shim/printer/plugins/utils/tokens.test.ts
+++ b/packages/ast/src/dot-shim/printer/plugins/utils/tokens.test.ts
@@ -10,4 +10,20 @@ describe('escape', () => {
   ])('should escape %s to %s', (value, expected) => {
     expect(escape(value)).toBe(expected);
   });
+
+  test('should escape multiple characters', () => {
+    expect(escape('\r\n"')).toBe(String.raw`\r\n\"`);
+  });
+
+  test('should not escape other characters', () => {
+    expect(escape('abc')).toBe('abc');
+  });
+
+  test('should not escape escaped characters', () => {
+    expect(escape(String.raw`\r\n\"`)).toBe(String.raw`\r\n\"`);
+  });
+
+  test('should not escape empty string', () => {
+    expect(escape('')).toBe('');
+  });
 });

--- a/packages/ast/src/dot-shim/printer/plugins/utils/tokens.ts
+++ b/packages/ast/src/dot-shim/printer/plugins/utils/tokens.ts
@@ -26,16 +26,22 @@ export function rightPadWith(right: string): (value: string) => string {
 /**
  * Escape a string for literal value in DOT language.
  *
+ * @remarks
  * The following characters are escaped:
- * - `\r` -> `\r`
- * - `\n` -> `\n`
- * - `"` -> `\"`
+ * - `\r` -> String.raw`\r`
+ * - `\n` -> String.raw`\n`
+ * - `"` -> String.raw`\"`
+ *
+ * But escaped characters are not escaped again.
  *
  * @param value - The string to escape
  * @returns The escaped string
  */
 export const escape = (value: string): string =>
-  value.replace(/[\r\n"]/g, escapeReplacer);
+  value.replace(/(?<!\\)"|[\r\n]/g, escapeReplacer);
+// NOTE: The regular expression used to escape the string is `/(?<!\\)"|[\r\n]/g`.
+// - `(?<!\\)"`: This part of the regular expression matches a double quote (`"`) **only if** it is **not preceded by a backslash**, effectively ignoring already-escaped quotes like `\"`.
+// - `[\r\n]`: This part matches every carriage return (`\r`) or newline (`\n`) character in the input, regardless of whether they are escaped.
 function escapeReplacer(match: string) {
   switch (match) {
     case '\r':

--- a/packages/ast/src/dot-shim/printer/plugins/utils/tokens.ts
+++ b/packages/ast/src/dot-shim/printer/plugins/utils/tokens.ts
@@ -23,12 +23,30 @@ export function rightPadWith(right: string): (value: string) => string {
   return (value: string) => value + right;
 }
 
+/**
+ * Escape a string for literal value in DOT language.
+ *
+ * The following characters are escaped:
+ * - `\r` -> `\r`
+ * - `\n` -> `\n`
+ * - `"` -> `\"`
+ *
+ * @param value - The string to escape
+ * @returns The escaped string
+ */
 export const escape = (value: string): string =>
-  value
-    .replace(/\\/g, '\\\\')
-    .replace(/\r/g, '\\r')
-    .replace(/\n/g, '\\n')
-    .replace(/"/g, '\\"');
+  value.replace(/[\r\n"]/g, escapeReplacer);
+function escapeReplacer(match: string) {
+  switch (match) {
+    case '\r':
+      return '\\r';
+    case '\n':
+      return '\\n';
+    default: // case '"':
+      return '\\"';
+  }
+}
+
 export const splitByLine = (value: string): string[] => value.split(EOL);
 
 export const align = (padding: string, eol: string) =>


### PR DESCRIPTION
This pull request fixes the string escaping in the DOT language.

Previously, certain characters were not properly escaped, causing issues with the rendering of DOT graphs.

This PR introduces a new `escape` function that correctly escapes characters such as `\r`, `\n`, and `"`. The function is used in the `tokens.test.ts` file to ensure proper escaping.

fix #1127 
fix #1202 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a patch to fix string escaping issues in the DOT language for improved graph representation.
	- Added a new function to escape specific characters in strings used within DOT format.

- **Tests**
	- Implemented a suite of unit tests to verify the functionality of the new escape function, ensuring accurate string escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->