### PR TITLE
Disable persisting credentials during repository checkout on CD

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Checkout Repo
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
       - uses: dtinth/setup-github-actions-caching-for-turbo@cc723b4600e40a6b8815b65701d8614b91e2669e # v1.3.0
         with:
           cache-prefix: turbo-


### PR DESCRIPTION
This pull request will prevent the CD workflow from persisting credentials during repository checkout. This change is made by setting the persist-credentials option to false in the CD workflow checkout repo step.

This fixes a problem where Pull Requests created by `changesets/action` do not meet the requirement to be merged into the main branch, where CI is performed.

See https://github.com/orgs/community/discussions/26220


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced security in the GitHub Actions workflow by modifying credential handling during the checkout process.
	- Conditional creation of an `.npmrc` file for npm publishing, improving authentication setup.

- **Bug Fixes**
	- Adjusted workflow steps to ensure proper execution based on job dependencies, maintaining the integrity of the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->