### PR TITLE
Update permissions in update-license-year.yaml workflow

### DIFF
--- a/.github/workflows/update-license-year.yaml
+++ b/.github/workflows/update-license-year.yaml
@@ -1,7 +1,7 @@
 name: Update copyright year(s) in license file
 
 permissions:
-  contents: write
+  contents: read
 
 on:
   schedule:
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1

--- a/.github/workflows/update-license-year.yaml
+++ b/.github/workflows/update-license-year.yaml
@@ -1,7 +1,7 @@
 name: Update copyright year(s) in license file
 
 permissions:
-  contents: read
+  contents: write
 
 on:
   schedule:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/update-license-year.yaml` file. The change grants write permissions to pull requests. 

* [`.github/workflows/update-license-year.yaml`](diffhunk://#diff-500febb231b843d6af30438c88dd25f6035cdd7ee38706682fa3fa6abc7cf3e6R15): Added write permissions for pull requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow permissions to enable automatic license year updates.
	- Enhanced repository maintenance automation with improved content modification capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->