### PR TITLE
Adjust HTML label AST handling for consistent behavior

### DIFF
--- a/.changeset/slimy-geckos-nail.md
+++ b/.changeset/slimy-geckos-nail.md
@@ -1,0 +1,6 @@
+---
+"@ts-graphviz/ast": major
+"@ts-graphviz/react": minor
+---
+
+Adjust HTML label AST handling for consistent behavior #1335

--- a/packages/ast/src/model-shim/from-model/plugins/utils/convert-attribute.test.ts
+++ b/packages/ast/src/model-shim/from-model/plugins/utils/convert-attribute.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'vitest';
+import { convertAttribute } from './convert-attribute.js';
+
+describe('convertAttribute', () => {
+  test('number', () => {
+    const result = convertAttribute('size', 1);
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "children": [],
+        "key": {
+          "children": [],
+          "location": null,
+          "quoted": false,
+          "type": "Literal",
+          "value": "size",
+        },
+        "location": null,
+        "type": "Attribute",
+        "value": {
+          "children": [],
+          "location": null,
+          "quoted": false,
+          "type": "Literal",
+          "value": "1",
+        },
+      }
+    `);
+  });
+
+  describe('string', () => {
+    test('quated', () => {
+      const result = convertAttribute('label', 'A');
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "children": [],
+          "key": {
+            "children": [],
+            "location": null,
+            "quoted": false,
+            "type": "Literal",
+            "value": "label",
+          },
+          "location": null,
+          "type": "Attribute",
+          "value": {
+            "children": [],
+            "location": null,
+            "quoted": true,
+            "type": "Literal",
+            "value": "A",
+          },
+        }
+      `);
+    });
+
+    describe('html-like', () => {
+      test('html', () => {
+        const result = convertAttribute('label', '<A>');
+        expect(result).toMatchInlineSnapshot(`
+          {
+            "children": [],
+            "key": {
+              "children": [],
+              "location": null,
+              "quoted": false,
+              "type": "Literal",
+              "value": "label",
+            },
+            "location": null,
+            "type": "Attribute",
+            "value": {
+              "children": [],
+              "location": null,
+              "quoted": "html",
+              "type": "Literal",
+              "value": "<A>",
+            },
+          }
+        `);
+      });
+    });
+  });
+});

--- a/packages/ast/src/model-shim/from-model/plugins/utils/convert-attribute.ts
+++ b/packages/ast/src/model-shim/from-model/plugins/utils/convert-attribute.ts
@@ -16,7 +16,7 @@ export function convertAttribute<K extends AttributeKey>(
           key: createElement('Literal', { value: key, quoted: false }, []),
           value: createElement(
             'Literal',
-            { value: trimmed.slice(1, trimmed.length - 1), quoted: 'html' },
+            { value: trimmed, quoted: 'html' },
             [],
           ),
         },

--- a/packages/ast/src/model-shim/to-model/plugins/EdgePlugin.ts
+++ b/packages/ast/src/model-shim/to-model/plugins/EdgePlugin.ts
@@ -15,7 +15,11 @@ export const EdgePlugin: ConvertToModelPlugin<EdgeASTNode> = {
         )
         .reduce(
           (acc, curr) => {
-            acc[curr.key.value] = curr.value.value;
+            if (curr.value.quoted === 'html') {
+              acc[curr.key.value] = `<${curr.value.value}>`;
+            } else {
+              acc[curr.key.value] = curr.value.value;
+            }
             return acc;
           },
           {} as { [key: string]: string },

--- a/packages/ast/src/model-shim/to-model/plugins/NodePlugin.ts
+++ b/packages/ast/src/model-shim/to-model/plugins/NodePlugin.ts
@@ -14,7 +14,11 @@ export const NodePlugin: ConvertToModelPlugin<NodeASTNode> = {
         )
         .reduce(
           (acc, curr) => {
-            acc[curr.key.value] = curr.value.value;
+            if (curr.value.quoted === 'html') {
+              acc[curr.key.value] = `<${curr.value.value}>`;
+            } else {
+              acc[curr.key.value] = curr.value.value;
+            }
             return acc;
           },
           {} as { [key: string]: string },

--- a/packages/ast/src/model-shim/to-model/to-model.test.ts
+++ b/packages/ast/src/model-shim/to-model/to-model.test.ts
@@ -1,8 +1,8 @@
 import { registerDefault } from '@ts-graphviz/core';
-registerDefault();
-import { expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { createElement } from '../../builder/create-element.js';
 import { toModel } from './to-model.js';
+registerDefault();
 
 test('brank ast throw error', () => {
   const ast = createElement('Dot', {}, []);
@@ -31,4 +31,50 @@ test('comment', () => {
   ]);
   const model = toModel(ast);
   expect(model.comment).toStrictEqual('This is comment');
+});
+
+describe('HTML Lavel', () => {
+  test('node label', () => {
+    const ast = createElement(
+      'Node',
+      {
+        id: createElement('Literal', { value: 'A', quoted: false }),
+      },
+      [
+        createElement('Attribute', {
+          key: createElement('Literal', { value: 'label', quoted: false }),
+          value: createElement('Literal', { value: 'A', quoted: 'html' }),
+        }),
+      ],
+    );
+
+    const model = toModel(ast);
+    expect(model.id).toStrictEqual('A');
+    expect(model.attributes.get('label')).toStrictEqual('<A>');
+  });
+
+  test('edge label', () => {
+    const ast = createElement(
+      'Edge',
+      {
+        targets: [
+          createElement('NodeRef', {
+            id: createElement('Literal', { value: 'A', quoted: false }),
+          }),
+          createElement('NodeRef', {
+            id: createElement('Literal', { value: 'B', quoted: false }),
+          }),
+        ],
+      },
+      [
+        createElement('Attribute', {
+          key: createElement('Literal', { value: 'label', quoted: false }),
+          value: createElement('Literal', { value: 'A', quoted: 'html' }),
+        }),
+      ],
+    );
+
+    const model = toModel(ast);
+    expect(model.attributes.get('label')).toStrictEqual('<A>');
+  });
 });

--- a/packages/react/src/hooks/useRenderedID.spec.tsx
+++ b/packages/react/src/hooks/useRenderedID.spec.tsx
@@ -23,6 +23,6 @@ describe('useRenderedID', () => {
     const { result } = renderHook(() => useRenderedID(<dot:b>bold</dot:b>), {
       wrapper: context(),
     });
-    expect(result.current).toBe('<<b>bold</b>>');
+    expect(result.current).toBe('<b>bold</b>');
   });
 });

--- a/packages/react/src/renderHTMLLike.ts
+++ b/packages/react/src/renderHTMLLike.ts
@@ -2,8 +2,7 @@ import type { ReactElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
 export function renderHTMLLike(label?: ReactElement): string {
-  const htmlLike = renderToStaticMarkup(label)
+  return renderToStaticMarkup(label)
     .replace(/<dot:port>(.+?)<\/dot:port>/gi, '<$1>')
     .replace(/<(\/?)dot:([a-z-]+)/gi, (_, $1, $2) => `<${$1}${$2}`);
-  return `<${htmlLike}>`;
 }

--- a/test/__snapshots__/to-dot.test.ts.snap
+++ b/test/__snapshots__/to-dot.test.ts.snap
@@ -28,13 +28,13 @@ exports[`Digraph > renders correctly by toDot method > has some attributes 1`] =
 exports[`Digraph > renders correctly by toDot method > label attribute behavior > html like 1`] = `
 "digraph {
   graph [
-    label = <<B>this is test for graph label</B>>;
+    label = <<<B>this is test for graph label</B>>>;
   ];
   edge [
-    label = <<U>this is test for edge label</U>>;
+    label = <<<U>this is test for edge label</U>>>;
   ];
   node [
-    label = <<I>this is test for node label</I>>;
+    label = <<<I>this is test for node label</I>>>;
   ];
 }"
 `;
@@ -142,13 +142,13 @@ exports[`Graph > renders correctly by toDot method > has some attributes 1`] = `
 exports[`Graph > renders correctly by toDot method > label attribute behavior > html like 1`] = `
 "graph {
   graph [
-    label = <<B>this is test for graph label</B>>;
+    label = <<<B>this is test for graph label</B>>>;
   ];
   edge [
-    label = <<U>this is test for edge label</U>>;
+    label = <<<U>this is test for edge label</U>>>;
   ];
   node [
-    label = <<I>this is test for node label</I>>;
+    label = <<<I>this is test for node label</I>>>;
   ];
 }"
 `;

--- a/test/issue.test.ts
+++ b/test/issue.test.ts
@@ -1,0 +1,379 @@
+import { parse, stringify } from '@ts-graphviz/ast';
+import { fromDot, toDot } from 'ts-graphviz';
+import { describe, expect, test } from 'vitest';
+
+describe('issue #1335', () => {
+  test('', () => {
+    const src = `digraph g {
+   a [label=<<table><tr><td>NOK</td></tr></table>>]
+   b [label=<<b>NOK<b>>]
+   c [label=<OK>];
+}`;
+    const ast = parse(src);
+    expect(ast).toMatchInlineSnapshot(`
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "children": [
+                  {
+                    "children": [],
+                    "key": {
+                      "children": [],
+                      "location": {
+                        "end": {
+                          "column": 12,
+                          "line": 2,
+                          "offset": 23,
+                        },
+                        "source": undefined,
+                        "start": {
+                          "column": 7,
+                          "line": 2,
+                          "offset": 18,
+                        },
+                      },
+                      "quoted": false,
+                      "type": "Literal",
+                      "value": "label",
+                    },
+                    "location": {
+                      "end": {
+                        "column": 51,
+                        "line": 2,
+                        "offset": 62,
+                      },
+                      "source": undefined,
+                      "start": {
+                        "column": 7,
+                        "line": 2,
+                        "offset": 18,
+                      },
+                    },
+                    "type": "Attribute",
+                    "value": {
+                      "children": [],
+                      "location": {
+                        "end": {
+                          "column": 51,
+                          "line": 2,
+                          "offset": 62,
+                        },
+                        "source": undefined,
+                        "start": {
+                          "column": 13,
+                          "line": 2,
+                          "offset": 24,
+                        },
+                      },
+                      "quoted": "html",
+                      "type": "Literal",
+                      "value": "<table><tr><td>NOK</td></tr></table>",
+                    },
+                  },
+                ],
+                "id": {
+                  "children": [],
+                  "location": {
+                    "end": {
+                      "column": 5,
+                      "line": 2,
+                      "offset": 16,
+                    },
+                    "source": undefined,
+                    "start": {
+                      "column": 4,
+                      "line": 2,
+                      "offset": 15,
+                    },
+                  },
+                  "quoted": false,
+                  "type": "Literal",
+                  "value": "a",
+                },
+                "location": {
+                  "end": {
+                    "column": 52,
+                    "line": 2,
+                    "offset": 63,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 4,
+                    "line": 2,
+                    "offset": 15,
+                  },
+                },
+                "type": "Node",
+              },
+              {
+                "children": [
+                  {
+                    "children": [],
+                    "key": {
+                      "children": [],
+                      "location": {
+                        "end": {
+                          "column": 12,
+                          "line": 3,
+                          "offset": 75,
+                        },
+                        "source": undefined,
+                        "start": {
+                          "column": 7,
+                          "line": 3,
+                          "offset": 70,
+                        },
+                      },
+                      "quoted": false,
+                      "type": "Literal",
+                      "value": "label",
+                    },
+                    "location": {
+                      "end": {
+                        "column": 24,
+                        "line": 3,
+                        "offset": 87,
+                      },
+                      "source": undefined,
+                      "start": {
+                        "column": 7,
+                        "line": 3,
+                        "offset": 70,
+                      },
+                    },
+                    "type": "Attribute",
+                    "value": {
+                      "children": [],
+                      "location": {
+                        "end": {
+                          "column": 24,
+                          "line": 3,
+                          "offset": 87,
+                        },
+                        "source": undefined,
+                        "start": {
+                          "column": 13,
+                          "line": 3,
+                          "offset": 76,
+                        },
+                      },
+                      "quoted": "html",
+                      "type": "Literal",
+                      "value": "<b>NOK<b>",
+                    },
+                  },
+                ],
+                "id": {
+                  "children": [],
+                  "location": {
+                    "end": {
+                      "column": 5,
+                      "line": 3,
+                      "offset": 68,
+                    },
+                    "source": undefined,
+                    "start": {
+                      "column": 4,
+                      "line": 3,
+                      "offset": 67,
+                    },
+                  },
+                  "quoted": false,
+                  "type": "Literal",
+                  "value": "b",
+                },
+                "location": {
+                  "end": {
+                    "column": 25,
+                    "line": 3,
+                    "offset": 88,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 4,
+                    "line": 3,
+                    "offset": 67,
+                  },
+                },
+                "type": "Node",
+              },
+              {
+                "children": [
+                  {
+                    "children": [],
+                    "key": {
+                      "children": [],
+                      "location": {
+                        "end": {
+                          "column": 12,
+                          "line": 4,
+                          "offset": 100,
+                        },
+                        "source": undefined,
+                        "start": {
+                          "column": 7,
+                          "line": 4,
+                          "offset": 95,
+                        },
+                      },
+                      "quoted": false,
+                      "type": "Literal",
+                      "value": "label",
+                    },
+                    "location": {
+                      "end": {
+                        "column": 17,
+                        "line": 4,
+                        "offset": 105,
+                      },
+                      "source": undefined,
+                      "start": {
+                        "column": 7,
+                        "line": 4,
+                        "offset": 95,
+                      },
+                    },
+                    "type": "Attribute",
+                    "value": {
+                      "children": [],
+                      "location": {
+                        "end": {
+                          "column": 17,
+                          "line": 4,
+                          "offset": 105,
+                        },
+                        "source": undefined,
+                        "start": {
+                          "column": 13,
+                          "line": 4,
+                          "offset": 101,
+                        },
+                      },
+                      "quoted": "html",
+                      "type": "Literal",
+                      "value": "OK",
+                    },
+                  },
+                ],
+                "id": {
+                  "children": [],
+                  "location": {
+                    "end": {
+                      "column": 5,
+                      "line": 4,
+                      "offset": 93,
+                    },
+                    "source": undefined,
+                    "start": {
+                      "column": 4,
+                      "line": 4,
+                      "offset": 92,
+                    },
+                  },
+                  "quoted": false,
+                  "type": "Literal",
+                  "value": "c",
+                },
+                "location": {
+                  "end": {
+                    "column": 19,
+                    "line": 4,
+                    "offset": 107,
+                  },
+                  "source": undefined,
+                  "start": {
+                    "column": 4,
+                    "line": 4,
+                    "offset": 92,
+                  },
+                },
+                "type": "Node",
+              },
+            ],
+            "directed": true,
+            "id": {
+              "children": [],
+              "location": {
+                "end": {
+                  "column": 10,
+                  "line": 1,
+                  "offset": 9,
+                },
+                "source": undefined,
+                "start": {
+                  "column": 9,
+                  "line": 1,
+                  "offset": 8,
+                },
+              },
+              "quoted": false,
+              "type": "Literal",
+              "value": "g",
+            },
+            "location": {
+              "end": {
+                "column": 2,
+                "line": 5,
+                "offset": 109,
+              },
+              "source": undefined,
+              "start": {
+                "column": 1,
+                "line": 1,
+                "offset": 0,
+              },
+            },
+            "strict": false,
+            "type": "Graph",
+          },
+        ],
+        "location": {
+          "end": {
+            "column": 2,
+            "line": 5,
+            "offset": 109,
+          },
+          "source": undefined,
+          "start": {
+            "column": 1,
+            "line": 1,
+            "offset": 0,
+          },
+        },
+        "type": "Dot",
+      }
+    `);
+    expect(stringify(ast)).toMatchInlineSnapshot(`
+      "digraph g {
+        a [
+          label = <<table><tr><td>NOK</td></tr></table>>;
+        ];
+        b [
+          label = <<b>NOK<b>>;
+        ];
+        c [
+          label = <OK>;
+        ];
+      }"
+    `);
+
+    const model = fromDot(src);
+
+    const dot = toDot(model);
+    expect(dot).toMatchInlineSnapshot(`
+      "digraph "g" {
+        "a" [
+          label = <<table><tr><td>NOK</td></tr></table>>;
+        ];
+        "b" [
+          label = <<b>NOK<b>>;
+        ];
+        "c" [
+          label = "OK";
+        ];
+      }"
+    `);
+  });
+});


### PR DESCRIPTION
### What was a problem

The `toDot` method did not correctly handle HTML labels within the Abstract Syntax Tree (AST), resulting in improperly quoted labels and invalid DOT output. This inconsistency affected the serialization of graphs containing HTML-like labels, leading to issues when rendering or processing such graphs.

### How this PR fixes the problem

This PR adjusts the handling of HTML labels in the AST to ensure that the `toDot` method produces valid DOT output. Specifically, it ensures that HTML labels are correctly quoted and serialized, maintaining the integrity of the graph structure. Tests have been added to verify the correct behavior for node and edge labels containing HTML, ensuring consistent and expected output.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

Fixes #1335

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of HTML-like labels to ensure they are preserved and formatted correctly in both parsing and rendering.
- **Tests**
	- Added comprehensive tests for attribute conversion, HTML-like label handling, and round-trip DOT source conversions.
	- Enhanced test coverage for nodes and edges with HTML-quoted labels.
- **Chores**
	- Updated project dependencies for improved stability and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->