### PR TITLE
chore: enable manual triggering of the main workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This pull request introduces a small change to the GitHub Actions workflow configuration. It adds support for manually triggering the workflow using the `workflow_dispatch` event.

* [`.github/workflows/main.yaml`](diffhunk://#diff-71cabc4177e41ea8f15a89eb65398fa8187739f68a2762706d84885cd8b2ddc3R7): Added the `workflow_dispatch` event under the `on:` section to allow manual triggering of the workflow.