### PR TITLE
Update Node.js engine requirement to >=20

### DIFF
--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -49,7 +49,7 @@
     "vite-plugin-dts": "^4.5.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -44,7 +44,7 @@
     "vite-plugin-dts": "^4.5.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -41,7 +41,7 @@
     "vite-plugin-dts": "^4.5.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,7 @@
     "vite-plugin-dts": "^4.5.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/ts-graphviz/package.json
+++ b/packages/ts-graphviz/package.json
@@ -50,7 +50,7 @@
     "vite-plugin-dts": "^4.5.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
This pull request updates the Node.js version requirement across multiple packages to ensure compatibility with newer features and improved security. The minimum required Node.js version has been changed from `>=18` to `>=20`.

Node.js version updates:

* Updated the `engines.node` field to `>=20` in the following `package.json` files:
  - `packages/adapter/package.json`
  - `packages/ast/package.json`
  - `packages/common/package.json`
  - `packages/core/package.json`
  - `packages/ts-graphviz/package.json`