### PR TITLE
Add .npmignore to exclude unnecessary files from npm package

### DIFF
--- a/packages/react/.npmignore
+++ b/packages/react/.npmignore
@@ -1,0 +1,4 @@
+src
+tsconfig.json
+typedoc.json
+vite.config.ts


### PR DESCRIPTION
Introduce a .npmignore file to prevent source files and configuration from being included in the npm package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package configuration to exclude development files from the npm package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->