### PR TITLE
fix: prevent publishing stable releases with @next tag

### DIFF
--- a/.changeset/thirty-rice-jog.md
+++ b/.changeset/thirty-rice-jog.md
@@ -1,0 +1,10 @@
+---
+"@ts-graphviz/adapter": patch
+"@ts-graphviz/ast": patch
+"@ts-graphviz/common": patch
+"@ts-graphviz/core": patch
+"@ts-graphviz/react": patch
+"ts-graphviz": patch
+---
+
+Fix CI workflow to prevent publishing stable releases with @next tag

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -86,7 +86,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish npm package with @next tag
-        if: ${{ steps.changesets.outputs.published == 'false' && github.actor != 'dependabot[bot]'}}
+        if: ${{ steps.changesets.outputs.published != 'true' && github.actor != 'dependabot[bot]'}}
         # - name: Creating .npmrc
         run: |
           cat << EOF > "$HOME/.npmrc"


### PR DESCRIPTION
## Summary
- Fixed CI workflow condition to prevent stable releases from being published with `@next` tag
- Changed condition from `== 'false'` to `!= 'true'` for more robust boolean checking
- Added patch changeset for all packages

## Problem
When releasing 3.0.0, the packages were incorrectly tagged as `next` in npm registry instead of only `latest`.

## Root Cause
The condition `steps.changesets.outputs.published == 'false'` in `.github/workflows/main.yaml:89` was evaluating incorrectly, causing the snapshot publish step to run even after a stable release.

## Solution
Changed the condition to `!= 'true'` which properly prevents the @next tag publishing step from running when `changesets/action` successfully publishes a stable release.

## Test Plan
- [ ] Merge this PR
- [ ] Verify the release workflow publishes packages with only `latest` tag
- [ ] Verify snapshot releases continue to work with `next` tag

Fixes #1446

🤖 Generated with [Claude Code](https://claude.com/claude-code)