### PR TITLE
fix: prevent @next tag publishing after Version Packages PR merge

### DIFF
--- a/.changeset/fix-release-tag-v2.md
+++ b/.changeset/fix-release-tag-v2.md
@@ -1,0 +1,10 @@
+---
+"@ts-graphviz/adapter": patch
+"@ts-graphviz/ast": patch
+"@ts-graphviz/common": patch
+"@ts-graphviz/core": patch
+"@ts-graphviz/react": patch
+"ts-graphviz": patch
+---
+
+Fix CI workflow to prevent @next tag publishing after Version Packages PR merge

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -86,7 +86,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish npm package with @next tag
-        if: ${{ steps.changesets.outputs.published != 'true' && github.actor != 'dependabot[bot]'}}
+        if: ${{ steps.changesets.outputs.published != 'true' && github.head_ref != 'changeset-release/main' && github.actor != 'dependabot[bot]'}}
         # - name: Creating .npmrc
         run: |
           cat << EOF > "$HOME/.npmrc"


### PR DESCRIPTION
## Summary
- Fixed CI workflow to prevent @next tag publishing when Version Packages PR is merged
- Added condition to check `github.head_ref != 'changeset-release/main'`

## Problem Analysis

### Previous Issue (#1480)
The previous fix changed `== 'false'` to `!= 'true'`, but this was insufficient.

### Current Problem
After merging #1480 and releasing v3.0.1, the @next tag step still executed because:

1. **Version Packages PR merge** → changesets publish → packages published
2. **No more changesets** in repo
3. `steps.changesets.outputs.published != 'true'` → evaluates to `true` (because no publish happened)
4. **@next tag step runs** (but doesn't publish because versions already exist)

### Root Cause
The condition `published != 'true'` cannot distinguish between:
- **"No changesets exist"** (should NOT run @next) ❌
- **"Changesets exist but not published"** (should run @next) ✅

## Solution
Added `github.head_ref != 'changeset-release/main'` to explicitly skip the @next tag step when:
- The Version Packages PR (`changeset-release/main`) is merged
- This PR is created by changesets/action and always results in a release

## Workflow Logic

```yaml
if: ${{ 
  steps.changesets.outputs.published != 'true' && 
  github.head_ref != 'changeset-release/main' && 
  github.actor != 'dependabot[bot]'
}}
```

| Scenario | `published` | `head_ref` | @next runs? |
|----------|------------|------------|-------------|
| Version Packages PR merged | `'true'` | `changeset-release/main` | ❌ No (published=true) |
| Regular PR merged (with changeset) | `'false'` | `feature/xxx` | ✅ Yes |
| Regular PR merged (no changeset) | `'false'` | `feature/xxx` | ✅ Yes (snapshot) |
| Direct push to main | `'false'` | empty | ✅ Yes |

## Test Plan
- [ ] Merge this PR
- [ ] Verify Version Packages PR is created
- [ ] Merge Version Packages PR
- [ ] Verify @next tag step is skipped
- [ ] Verify packages are published with only `latest` tag

Fixes #1446

🤖 Generated with [Claude Code](https://claude.com/claude-code)